### PR TITLE
feat: animation updates and disaster flow

### DIFF
--- a/app/src/main/java/io/github/sasori_256/town_planning/App.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/App.java
@@ -15,7 +15,15 @@ import io.github.sasori_256.town_planning.entity.resident.ResidentType;
 import io.github.sasori_256.town_planning.map.controller.GameMapController;
 import io.github.sasori_256.town_planning.map.model.GameMap;
 
+/**
+ * アプリケーションのエントリーポイント。
+ */
 public class App {
+  /**
+   * ゲームを初期化して起動する。
+   *
+   * @param args 起動引数
+   */
   public static void main(String[] args) {
     final int WIDTH = 640;
     final int HEIGHT = 640;

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/core/GameLoop.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/core/GameLoop.java
@@ -26,11 +26,20 @@ public class GameLoop implements Runnable {
   private static final double TIME_STEP = 1.0 / 30.0;
   private static final long TIME_STEP_NANO = (long) (TIME_STEP * 1_000_000_000);
 
+  /**
+   * ゲームループを生成する。
+   *
+   * @param updateCallback 更新処理
+   * @param renderCallback 描画処理
+   */
   public GameLoop(DoubleConsumer updateCallback, Runnable renderCallback) {
     this.updateCallback = updateCallback;
     this.renderCallback = renderCallback;
   }
 
+  /**
+   * ゲームループを開始する。
+   */
   public synchronized void start() {
     if (thread == null) {
       try {
@@ -83,6 +92,9 @@ public class GameLoop implements Runnable {
     }
   }
 
+  /**
+   * ループ処理を実行する。
+   */
   @Override
   public void run() {
     long lastTime = System.nanoTime(); // 前フレームの時刻

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/core/strategy/CompositeGameEffect.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/core/strategy/CompositeGameEffect.java
@@ -13,14 +13,25 @@ import java.util.List;
 public class CompositeGameEffect implements GameEffect {
   private final List<GameEffect> effects = new ArrayList<>();
 
+  /**
+   * エフェクトを追加する。
+   *
+   * @param effect エフェクト
+   */
   public void add(GameEffect effect) {
     effects.add(effect);
   }
 
+  /**
+   * エフェクトを削除する。
+   *
+   * @param effect エフェクト
+   */
   public void remove(GameEffect effect) {
     effects.remove(effect);
   }
 
+  /** {@inheritDoc} */
   @Override
   public void execute(GameContext context, BaseGameEntity self) {
     // リストのコピーを作成してConcurrentModificationExceptionを防ぐ（簡易実装）

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/core/strategy/CompositeUpdateStrategy.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/core/strategy/CompositeUpdateStrategy.java
@@ -12,21 +12,40 @@ public class CompositeUpdateStrategy implements UpdateStrategy {
   private GameAction action;
   private final CompositeGameEffect compositeEffect = new CompositeGameEffect();
 
+  /**
+   * 複合更新ストラテジーを生成する。
+   */
   public CompositeUpdateStrategy() {
   }
 
+  /**
+   * 排他実行するアクションを設定する。
+   *
+   * @param action アクション
+   */
   public void setAction(GameAction action) {
     this.action = action;
   }
 
+  /**
+   * 併用するエフェクトを追加する。
+   *
+   * @param effect エフェクト
+   */
   public void addEffect(GameEffect effect) {
     this.compositeEffect.add(effect);
   }
 
+  /**
+   * 併用するエフェクトを削除する。
+   *
+   * @param effect エフェクト
+   */
   public void removeEffect(GameEffect effect) {
     this.compositeEffect.remove(effect);
   }
 
+  /** {@inheritDoc} */
   @Override
   public void update(GameContext context, BaseGameEntity self) {
     // 1. 並行エフェクトの実行（常に実行）

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/core/strategy/UpdateStrategy.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/core/strategy/UpdateStrategy.java
@@ -8,5 +8,11 @@ import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
  */
 @FunctionalInterface
 public interface UpdateStrategy {
+  /**
+   * エンティティの更新処理を行う。
+   *
+   * @param context ゲームコンテキスト
+   * @param self    対象エンティティ
+   */
   void update(GameContext context, BaseGameEntity self);
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/event/EventBus.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/event/EventBus.java
@@ -15,7 +15,25 @@ public class EventBus {
 
   /**
    * イベントを購読する。
-   * 
+   *
+   * <h2>購読方法</h2>
+   *
+   * イベントを購読(値の変更などを検知)したいオブジェクトに対して以下を適用する。
+   *
+   * ```java
+   * Subscription sub =
+   * eventBus.subscribe(購読したいイベント.class, event -> {
+   * イベント発生時に実行される処理;
+   * });
+   * ```
+   *
+   * また、Windowパネルなどが破棄されるときにはunsubscribeが必要になる。
+   * unsubscribeのための関数はsubに入っているので、そこからunsubscribeを実行すれば良い。
+   *
+   * ```java
+   * sub.unsubscribe();
+   * ```
+   *
    * @param <T>       イベントの型
    * @param eventType 購読したいイベントのクラスオブジェクト
    * @param listener  イベント発生時に実行される処理
@@ -31,7 +49,17 @@ public class EventBus {
 
   /**
    * イベントを発行する。
-   * 
+   *
+   * <h2>発行方法</h2>
+   *
+   * 以下により発行したいイベントとその引数を指定することでイベントの発行が可能。
+   *
+   * ```java
+   * eventBus.publish(発行したいイベントのRecordクラス(必要な引数));
+   * ```
+   *
+   * 引数では、SoulChangedEvent(currentSoul)のようにフィールドを変更したときの数値など、伝達するべき値を引数に入れる。
+   *
    * @param event 発行するイベントオブジェクト
    */
   public void publish(Object event) {

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/event/Subscription.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/event/Subscription.java
@@ -1,6 +1,12 @@
 package io.github.sasori_256.town_planning.common.event;
 
+/**
+ * 購読解除を行うためのインターフェース。
+ */
 @FunctionalInterface
 public interface Subscription {
+  /**
+   * 購読を解除する。
+   */
   void unsubscribe();
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/AnimationManager.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/AnimationManager.java
@@ -21,6 +21,9 @@ import javax.imageio.ImageIO;
 public class AnimationManager {
   private final Map<String, AnimationStorage> animations = new HashMap<>();
 
+  /**
+   * アニメーションマネージャを生成し、画像を読み込む。
+   */
   public AnimationManager() {
     this.loadAnimations();
   }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/AnimationManager.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/AnimationManager.java
@@ -1,7 +1,5 @@
 package io.github.sasori_256.town_planning.common.ui;
 
-import java.awt.Graphics;
-import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.net.URL;
@@ -9,247 +7,159 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.imageio.ImageIO;
-import javax.swing.JComponent;
-import javax.swing.Timer;
 
 /**
- * アニメーション（連番 PNG）を管理し、再生・描画するクラス
+ * アニメーション（連番 PNG）を管理し、フレームを取得するクラス。
  *
- * 使用法:
- * - コンストラクタで resources/animations 下の PNG を読み込む
- * - play("walk", 12, x, y) のようにして再生を登録する
- *
- * - ファイル名は末尾に番号がついていることを期待します（例: walk_001.png, walk_002.png）
- * - 番号部分のパターンは (.*?)[_-]?(\\d+) を想定し、数値でソートします
+ * <p>ファイル名は末尾に番号がついていることを期待します（例: walk_001.png）。
  */
-public class AnimationManager extends JComponent {
-	private final Map<String, AnimationStorage> animations = new HashMap<>();
-	private final List<PlayingAnimation> playing = new ArrayList<>();
+public class AnimationManager {
+  private final Map<String, AnimationStorage> animations = new HashMap<>();
 
-	// 汎用タイマーで repaint をトリガーする（UI スレッドで動く）
-	private Timer timer;
+  public AnimationManager() {
+    this.loadAnimations();
+  }
 
-	public AnimationManager() {
-		this.loadAnimations();
-		this.setOpaque(false);
-	}
+  /** resources/animations にある画像を読み込む。 */
+  public void loadAnimations() {
+    URL animationsUrl = this.getClass().getClassLoader().getResource("animations");
+    String path = animationsUrl != null ? animationsUrl.getPath() : null;
+    File dir = path != null ? new File(path) : null;
 
-	/** resources/animations にある画像を読み込む */
-	public void loadAnimations() {
-		URL animationsUrl = this.getClass().getClassLoader().getResource("animations");
-		String path = animationsUrl != null ? animationsUrl.getPath() : null;
-		File dir = path != null ? new File(path) : null;
+    List<File> fileList = new ArrayList<>();
+    if (dir != null && dir.exists()) {
+      // 再帰的に検索
+      java.util.Deque<File> stack = new java.util.ArrayDeque<>();
+      stack.push(dir);
+      while (!stack.isEmpty()) {
+        File current = stack.pop();
+        File[] children = current.listFiles();
+        if (children == null) {
+          continue;
+        }
+        for (File child : children) {
+          if (child.isDirectory()) {
+            stack.push(child);
+          } else if (child.getName().toLowerCase().endsWith(".png")) {
+            fileList.add(child);
+          }
+        }
+      }
+    }
 
-		List<File> fileList = new ArrayList<>();
-		if (dir != null && dir.exists()) {
-			// 再帰的に検索
-			java.util.Deque<File> stack = new java.util.ArrayDeque<>();
-			stack.push(dir);
-			while (!stack.isEmpty()) {
-				File current = stack.pop();
-				File[] children = current.listFiles();
-				if (children == null)
-					continue;
-				for (File child : children) {
-					if (child.isDirectory()) {
-						stack.push(child);
-					} else if (child.getName().toLowerCase().endsWith(".png")) {
-						fileList.add(child);
-					}
-				}
-			}
-		}
+    Pattern pattern = Pattern.compile("^(.*?)[_\\-]?(\\d+)$");
+    Map<String, List<FileWithIndex>> grouped = new HashMap<>();
+    for (File file : fileList) {
+      String name = file.getName().replaceFirst("[.][^.]+$", "").toLowerCase();
+      Matcher matcher = pattern.matcher(name);
+      String base;
+      int idx = 0;
+      if (matcher.matches()) {
+        base = matcher.group(1).isEmpty() ? name : matcher.group(1);
+        try {
+          idx = Integer.parseInt(matcher.group(2));
+        } catch (NumberFormatException e) {
+          idx = 0;
+        }
+      } else {
+        base = name;
+        idx = 0;
+      }
+      grouped.computeIfAbsent(base, k -> new ArrayList<>()).add(new FileWithIndex(file, idx));
+    }
 
-		// baseName -> list of (file, index)
-		Pattern p = Pattern.compile("^(.*?)[_\\-]?(\\d+)$");
-		Map<String, List<FileWithIndex>> grouped = new HashMap<>();
-		for (File f : fileList) {
-			String name = f.getName().replaceFirst("[.][^.]+$", "").toLowerCase();
-			Matcher m = p.matcher(name);
-			String base;
-			int idx = 0;
-			if (m.matches()) {
-				base = m.group(1).isEmpty() ? name : m.group(1);
-				try {
-					idx = Integer.parseInt(m.group(2));
-				} catch (NumberFormatException e) {
-					idx = 0;
-				}
-			} else {
-				base = name;
-				idx = 0;
-			}
-			grouped.computeIfAbsent(base, k -> new ArrayList<>()).add(new FileWithIndex(f, idx));
-		}
+    for (Map.Entry<String, List<FileWithIndex>> entry : grouped.entrySet()) {
+      String base = entry.getKey();
+      List<FileWithIndex> list = entry.getValue();
+      Collections.sort(list, Comparator.comparingInt(o -> o.index));
+      List<BufferedImage> frames = new ArrayList<>();
+      for (FileWithIndex fi : list) {
+        try {
+          BufferedImage img = ImageIO.read(fi.file);
+          if (img != null) {
+            frames.add(img);
+          }
+        } catch (Exception ex) {
+          System.err.println("Error loading animation frame: " + fi.file.getName());
+          ex.printStackTrace();
+        }
+      }
+      if (!frames.isEmpty()) {
+        AnimationStorage storage = new AnimationStorage(base, frames);
+        this.animations.put(base.toLowerCase(), storage);
+        System.out.println("Loaded animation: " + base + " (" + frames.size() + " frames)");
+      }
+    }
+  }
 
-		for (Map.Entry<String, List<FileWithIndex>> e : grouped.entrySet()) {
-			String base = e.getKey();
-			List<FileWithIndex> list = e.getValue();
-			// インデックスでソートする
-			Collections.sort(list, Comparator.comparingInt(o -> o.index));
-			List<BufferedImage> frames = new ArrayList<>();
-			for (FileWithIndex fi : list) {
-				try {
-					BufferedImage img = ImageIO.read(fi.file);
-					if (img != null)
-						frames.add(img);
-				} catch (Exception ex) {
-					System.err.println("Error loading animation frame: " + fi.file.getName());
-					ex.printStackTrace();
-				}
-			}
-			if (!frames.isEmpty()) {
-				AnimationStorage storage = new AnimationStorage(base, frames);
-				this.animations.put(base.toLowerCase(), storage);
-				System.out.println("Loaded animation: " + base + " (" + frames.size() + " frames)");
-			}
-		}
-	}
+  /**
+   * 指定したフレームを取得する。
+   *
+   * @param name       アニメーション名（拡張子・番号なし、小文字大文字不問）
+   * @param frameIndex フレーム番号
+   * @param loop       ループ再生する場合は true
+   * @return フレーム画像（存在しない場合は null）
+   */
+  public BufferedImage getFrame(String name, int frameIndex, boolean loop) {
+    if (name == null) {
+      return null;
+    }
+    AnimationStorage storage = this.animations.get(name.toLowerCase());
+    if (storage == null || storage.frames.isEmpty()) {
+      return null;
+    }
+    int count = storage.frames.size();
+    if (count <= 0) {
+      return null;
+    }
+    int idx = frameIndex;
+    if (loop) {
+      idx = Math.floorMod(frameIndex, count);
+    } else {
+      idx = Math.max(0, Math.min(frameIndex, count - 1));
+    }
+    return storage.frames.get(idx);
+  }
 
-	/**
-	 * 指定した名前のアニメーションを指定フレームレートで x,y に描画する（doLoop が true の場合はループ再生）
-	 * 
-	 * @param name      アニメーション名（拡張子・番号なし、小文字大文字不問）
-	 * @param frameRate 1 秒あたりのフレーム数（0 以下の場合は 1 として扱われます）
-	 * @param x         描画位置の X 座標
-	 * @param y         描画位置の Y 座標
-	 * @param doLoop    true の場合は最後のフレームまで再生した後に先頭に戻ってループ再生し、false の場合は 1 回のみ再生します
-	 */
-	public PlayingAnimation play(String name, int frameRate, double x, double y, boolean doLoop) {
-		if (name == null)
-			return null;
-		AnimationStorage storage = this.animations.get(name.toLowerCase());
-		if (storage == null) {
-			System.err.println("Animation not found: " + name);
-			return null;
-		}
-		System.out.println("Start animation: " + name + " at (" + x + "," + y + ") with frameRate " + frameRate);
-		if (frameRate <= 0)
-			frameRate = 1;
-		PlayingAnimation pa = new PlayingAnimation(storage, frameRate, x, y, doLoop, System.currentTimeMillis());
-		synchronized (this.playing) {
-			this.playing.add(pa);
-		}
-		ensureTimerRunning();
-		this.repaint();
-		return pa;
-	}
+  /**
+   * アニメーションのフレーム数を返す。
+   *
+   * @param name アニメーション名
+   * @return フレーム数（見つからない場合は0）
+   */
+  public int getFrameCount(String name) {
+    if (name == null) {
+      return 0;
+    }
+    AnimationStorage storage = this.animations.get(name.toLowerCase());
+    if (storage == null) {
+      return 0;
+    }
+    return storage.frames.size();
+  }
 
-	public void stop(PlayingAnimation pa) {
-		if (pa == null)
-			return;
-		synchronized (this.playing) {
-			this.playing.remove(pa);
-		}
-	}
+  private static final class FileWithIndex {
+    final File file;
+    final int index;
 
-	private void ensureTimerRunning() {
-		// TODO: オリジナルのタイマーを持つのではなく、GameLoopから呼び出されるように変更する
-		if (this.timer == null) {
-			// 40ms 毎に repaint（最終描画タイミングは各アニメーションの fps を尊重する）
-			this.timer = new Timer(40, e -> this.repaint());
-			this.timer.setRepeats(true);
-			this.timer.start();
-		} else if (!this.timer.isRunning()) {
-			this.timer.start();
-		}
-	}
+    FileWithIndex(File file, int idx) {
+      this.file = file;
+      this.index = idx;
+    }
+  }
 
-	@Override
-	protected void paintComponent(Graphics g) {
-		super.paintComponent(g);
-		long now = System.currentTimeMillis();
-		synchronized (this.playing) {
-			Iterator<PlayingAnimation> it = this.playing.iterator();
-			while (it.hasNext()) {
-				PlayingAnimation pa = it.next();
-				if (pa.isFinished(now)) {
-					it.remove();
-					continue;
-				}
-				BufferedImage img = pa.getCurrentFrame(now);
-				if (img != null) {
-					g.drawImage(img, (int) Math.round(pa.x), (int) Math.round(pa.y), null);
-				}
-			}
-		}
-	}
+  private static final class AnimationStorage {
+    private final String name;
+    private final List<BufferedImage> frames;
 
-	// 補助クラス
-	private static final class FileWithIndex {
-		final File file;
-		final int index;
-
-		FileWithIndex(File f, int idx) {
-			this.file = f;
-			this.index = idx;
-		}
-	}
-
-	public static final class AnimationStorage {
-		private final String name;
-		private final List<BufferedImage> frames;
-		Point2D.Double size = new Point2D.Double();
-
-		public void loadSize() {
-			if (frames.isEmpty())
-				return;
-			BufferedImage img = frames.get(0);
-			this.size.x = img.getWidth(null);
-			this.size.y = img.getHeight(null);
-			if (this.size.x == -1 || this.size.y == -1) {
-				System.err.println("Failed to get image size for: " + this.name);
-				this.size = new Point2D.Double(64.0, 32.0);
-				return;
-			}
-		}
-
-		AnimationStorage(String name, List<BufferedImage> frames) {
-			this.name = name;
-			this.frames = frames;
-			this.loadSize();
-		}
-	}
-
-	private static final class PlayingAnimation {
-		private final AnimationStorage storage;
-		private final double x;
-		private final double y;
-		private final boolean doLoop;
-		private final long startMs;
-		private final long frameDurationMs;
-
-		PlayingAnimation(AnimationStorage storage, int frameRate, double x, double y, boolean doLoop, long startMs) {
-			this.storage = storage;
-			this.x = x;
-			this.y = y;
-			this.doLoop = doLoop;
-			this.startMs = startMs;
-			this.frameDurationMs = Math.max(1, 1000L / frameRate);
-		}
-
-		BufferedImage getCurrentFrame(long nowMs) {
-			if (storage == null || storage.frames.isEmpty())
-				return null;
-			long elapsed = Math.max(0, nowMs - this.startMs);
-			int idx = (int) ((elapsed / this.frameDurationMs) % storage.frames.size());
-			return storage.frames.get(idx);
-		}
-
-		boolean isFinished(long nowMs) {
-			if (doLoop)
-				return false;
-			long elapsed = Math.max(0, nowMs - this.startMs);
-			int totalFrames = storage.frames.size();
-			long totalDuration = totalFrames * frameDurationMs;
-			return elapsed >= totalDuration;
-		}
-	}
+    AnimationStorage(String name, List<BufferedImage> frames) {
+      this.name = name;
+      this.frames = frames;
+    }
+  }
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/CustomButton.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/CustomButton.java
@@ -11,6 +11,9 @@ import javax.swing.JButton;
 
 import io.github.sasori_256.town_planning.common.ui.ImageManager.ImageStorage;
 
+/**
+ * 画像表示や押下アニメーション付きのボタン。
+ */
 public class CustomButton extends JButton {
   private int originalWidth;
   private int originalHeight;
@@ -39,6 +42,11 @@ public class CustomButton extends JButton {
     this.setVerticalTextPosition(JButton.BOTTOM);
   }
 
+  /**
+   * テキストのみのボタンを生成する。
+   *
+   * @param text 表示テキスト
+   */
   public CustomButton(String text) {
     this.textContent = text;
     this.originalImage = null;
@@ -48,6 +56,12 @@ public class CustomButton extends JButton {
     textPositionOptimize();
   }
 
+  /**
+   * 画像付きのボタンを生成する。
+   *
+   * @param text         表示テキスト
+   * @param imageStorage 画像情報
+   */
   public CustomButton(String text, ImageStorage imageStorage) {
     this.textContent = text;
     this.originalImage = imageStorage.getImage();
@@ -56,10 +70,23 @@ public class CustomButton extends JButton {
     setImage(imageStorage.getImage(), (int) imageStorage.size.x, (int) imageStorage.size.y);
   }
 
+  /**
+   * 元のテキストを返す。
+   *
+   * @return テキスト
+   */
   public String getTextContent() {
     return textContent;
   }
 
+  /**
+   * 表示位置とサイズを設定し、内部の基準座標を更新する。
+   *
+   * @param x      左上X
+   * @param y      左上Y
+   * @param width  幅
+   * @param height 高さ
+   */
   public void setCustomBounds(int x, int y, int width, int height) {
     super.setBounds(x, y, width, height);
     this.setPreferredSize(new Dimension(width, height));
@@ -80,6 +107,13 @@ public class CustomButton extends JButton {
     }
   }
 
+  /**
+   * 表示画像とサイズを設定する。
+   *
+   * @param image 画像
+   * @param width 幅
+   * @param height 高さ
+   */
   public void setImage(Image image, int width, int height) {
     // 通常のボタンの外観を非表示にする
     this.setContentAreaFilled(false);
@@ -217,6 +251,7 @@ public class CustomButton extends JButton {
     animationThread.start();
   }
 
+  /** {@inheritDoc} */
   @Override
   public void removeNotify() { // コンポーネントが破棄されるときにアニメーションを停止
     if (animationThread != null && animationThread.isAlive()) {

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/GameWindow.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/GameWindow.java
@@ -46,6 +46,15 @@ class GameMapPanel extends JPanel {
   private final PaintObjectSelectUI paintObjectSelectUI;
   private final ReadWriteLock stateLock;
 
+  /**
+   * マップ描画パネルを生成する。
+   *
+   * @param gameMap   マップ
+   * @param gameModel ゲームモデル
+   * @param camera    カメラ
+   * @param root      ルートカテゴリ
+   * @param stateLock 状態ロック
+   */
   public GameMapPanel(GameMap gameMap, GameModel gameModel, Camera camera, CategoryNode root,
       ReadWriteLock stateLock) {
     this.gameMap = gameMap;
@@ -164,6 +173,9 @@ class GameMapPanel extends JPanel {
     return true;
   }
 
+  /**
+   * UIを再描画する。
+   */
   public void repaintUI() {
     this.paintObjectSelectUI.repaintUI();
   }
@@ -274,6 +286,11 @@ public class GameWindow extends JFrame {
     this.add(gameMapPanel, BorderLayout.CENTER);
     setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
     this.addComponentListener(new ComponentAdapter() {
+      /**
+       * ウィンドウサイズ変更時の処理を行う。
+       *
+       * @param e イベント
+       */
       @Override
       public void componentResized(java.awt.event.ComponentEvent e) {
         gameMapPanel.repaintUI();

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/GameWindow.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/GameWindow.java
@@ -18,6 +18,7 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import io.github.sasori_256.town_planning.common.event.EventBus;
+import io.github.sasori_256.town_planning.common.event.Subscription;
 import io.github.sasori_256.town_planning.common.event.events.MapUpdatedEvent;
 import io.github.sasori_256.town_planning.common.ui.gameObjectSelect.controller.CategoryNode;
 import io.github.sasori_256.town_planning.common.ui.gameObjectSelect.controller.NodeMenuInitializer;
@@ -187,19 +188,19 @@ class GameMapPanel extends JPanel {
   }
 
   private static final class DrawEntry {
-      private static final Comparator<DrawEntry> DEPTH_ORDER = Comparator
-          .comparingDouble((DrawEntry entry) -> entry.depth)
-          .thenComparingDouble(entry -> entry.y)
-          .thenComparingDouble(entry -> entry.x)
-          .thenComparingInt(entry -> {
-            if (entry.kind == DrawKind.BUILDING_TILE) {
-              return 0;
-            }
-            if (entry.kind == DrawKind.RESIDENT) {
-              return 1;
-            }
-            return 2;
-          });
+    private static final Comparator<DrawEntry> DEPTH_ORDER = Comparator
+        .comparingDouble((DrawEntry entry) -> entry.depth)
+        .thenComparingDouble(entry -> entry.y)
+        .thenComparingDouble(entry -> entry.x)
+        .thenComparingInt(entry -> {
+          if (entry.kind == DrawKind.BUILDING_TILE) {
+            return 0;
+          }
+          if (entry.kind == DrawKind.RESIDENT) {
+            return 1;
+          }
+          return 2;
+        });
 
     private final double x;
     private final double y;
@@ -276,7 +277,8 @@ public class GameWindow extends JFrame {
     gameMapPanel.addMouseWheelListener(listener);
     gameMapPanel.addKeyListener(listener);
     gameMapPanel.setFocusable(true);
-    eventBus.subscribe(MapUpdatedEvent.class, event -> {
+    // TODO: onCloseなる関数でWindowのフレーム破棄時にunsubscribeするようにする
+    Subscription mapSub = eventBus.subscribe(MapUpdatedEvent.class, event -> {
       if (SwingUtilities.isEventDispatchThread()) {
         gameMapPanel.repaint();
       } else {
@@ -301,5 +303,3 @@ public class GameWindow extends JFrame {
     setVisible(true);
   }
 }
-
-

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/ImageManager.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/ImageManager.java
@@ -80,6 +80,9 @@ public class ImageManager extends Component {
 
   }
 
+  /**
+   * 画像マネージャを生成し、画像を読み込む。
+   */
   public ImageManager() {
     this.loadImages();
   }
@@ -115,6 +118,9 @@ public class ImageManager extends Component {
     final BufferedImage image;
     Point2D.Double size = new Point2D.Double(); // サイズは読み取り直しが必要な場合があるため、finalにしない
 
+    /**
+     * 画像サイズを読み込む。
+     */
     public void loadSize() {
       if (this.image == null) {
         System.err.println("Cannot load size for null image: " + this.name);
@@ -129,16 +135,32 @@ public class ImageManager extends Component {
       }
     }
 
+    /**
+     * 画像情報を生成する。
+     *
+     * @param name  画像名
+     * @param image 画像
+     */
     public ImageStorage(String name, BufferedImage image) {
       this.name = name;
       this.image = image;
       this.loadSize();
     }
 
+    /**
+     * 画像名を返す。
+     *
+     * @return 画像名
+     */
     public String getName() {
       return name;
     }
 
+    /**
+     * 画像を返す。
+     *
+     * @return 画像
+     */
     public BufferedImage getImage() {
       return image;
     }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/PaintObjectSelectUI.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/PaintObjectSelectUI.java
@@ -24,6 +24,13 @@ public class PaintObjectSelectUI {
   // private GameMapController gameMapController;
   private double UIScale = 1;
 
+  /**
+   * UI描画クラスを生成する。
+   *
+   * @param imageManager 画像マネージャ
+   * @param panel        描画先パネル
+   * @param root         ルートカテゴリ
+   */
   public PaintObjectSelectUI(ImageManager imageManager, GameMapPanel panel, CategoryNode root) {
     this.imageManager = imageManager;
     this.panel = panel;
@@ -157,8 +164,9 @@ public class PaintObjectSelectUI {
 
   /**
    * オブジェクトの選択状態を変更する
-   * 
-   * @param objectName
+   *
+   * @param objectName 表示名
+   * @param objectNode 対象ノード
    */
   public void setSelectedObject(String objectName, MenuNode objectNode) {
     if (!(objectNode instanceof BuildingNode || objectNode instanceof DisasterNode)) {
@@ -284,8 +292,8 @@ public class PaintObjectSelectUI {
 
   /**
    * UIのスケールを設定する
-   * 
-   * @param scale
+   *
+   * @param scale UIスケール
    */
   public void setUIScale(double scale) {
     UIScale = scale;

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/BuildingNode.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/BuildingNode.java
@@ -9,12 +9,23 @@ import io.github.sasori_256.town_planning.entity.model.GameModel;
 import io.github.sasori_256.town_planning.map.controller.GameMapController;
 import io.github.sasori_256.town_planning.map.controller.handler.PlaceBuildingHandler;
 
+/**
+ * 建物選択用のメニューノード。
+ */
 public class BuildingNode implements MenuNode {
     private final BuildingType type;
     private final Function<Point2D.Double, Building> generator;
     private final GameMapController gameMapController;
     private final GameModel gameModel;
 
+    /**
+     * 建物ノードを生成する。
+     *
+     * @param buildingType      建物種別
+     * @param generator         建物生成関数
+     * @param gameMapController マップコントローラ
+     * @param gameModel         ゲームモデル
+     */
     public BuildingNode(BuildingType buildingType, Function<Point2D.Double, Building> generator,
         GameMapController gameMapController, GameModel gameModel) {
         this.type = buildingType;
@@ -23,19 +34,28 @@ public class BuildingNode implements MenuNode {
         this.gameModel = gameModel;
     }
 
+    /**
+     * 建物種別を返す。
+     *
+     * @return 建物種別
+     */
     public BuildingType getType() { return type; }
 
+    /** {@inheritDoc} */
     @Override
     public String getName() { return type.getDisplayName(); }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isLeaf() { return true; }
 
+    /** {@inheritDoc} */
     @Override
     public ArrayList<MenuNode> getChildren() {
         throw new UnsupportedOperationException("BuildingNode is a leaf node and does not have children");
     }
 
+    /** {@inheritDoc} */
     @Override
     public void actionPerformed(java.awt.event.ActionEvent e) {
         //TODO: Viewと連携する.

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/CategoryNode.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/CategoryNode.java
@@ -2,22 +2,40 @@ package io.github.sasori_256.town_planning.common.ui.gameObjectSelect.controller
 
 import java.util.ArrayList;
 
+/**
+ * メニューのカテゴリノード。
+ */
 public class CategoryNode implements MenuNode {
     private final String name;
     private ArrayList<MenuNode> children = new ArrayList<>();
 
+    /**
+     * カテゴリノードを生成する。
+     *
+     * @param name 表示名
+     */
     public CategoryNode(String name) { this.name = name; }
+
+    /**
+     * 子ノードを追加する。
+     *
+     * @param node 追加するノード
+     */
     public void add(MenuNode node) { children.add(node); }
     
+    /** {@inheritDoc} */
     @Override
     public String getName() { return name; }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isLeaf() { return false; }
 
+    /** {@inheritDoc} */
     @Override
     public ArrayList<MenuNode> getChildren() { return children; }
     
+    /** {@inheritDoc} */
     @Override
     public void actionPerformed(java.awt.event.ActionEvent e) {
         //TODO: Viewと連携する.

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/DisasterNode.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/DisasterNode.java
@@ -6,6 +6,7 @@ import java.awt.geom.Point2D;
 
 import io.github.sasori_256.town_planning.entity.disaster.Disaster;
 import io.github.sasori_256.town_planning.entity.disaster.DisasterType;
+import io.github.sasori_256.town_planning.entity.model.GameModel;
 import io.github.sasori_256.town_planning.map.controller.GameMapController;
 import io.github.sasori_256.town_planning.map.controller.handler.ActionDisasterHandler;
 import io.github.sasori_256.town_planning.map.model.MapContext;
@@ -14,12 +15,15 @@ public class DisasterNode implements MenuNode {
     private final DisasterType type;
     private final Function<Point2D.Double, Disaster> generator;
     private final GameMapController gameMapController;
+    private final GameModel gameModel;
     private final MapContext mapContext;
 
-    public DisasterNode(DisasterType disasterType, Function<Point2D.Double, Disaster> generator, GameMapController gameMapController, MapContext mapContext) {
+    public DisasterNode(DisasterType disasterType, Function<Point2D.Double, Disaster> generator, GameMapController gameMapController,
+        GameModel gameModel, MapContext mapContext) {
         this.type = disasterType;
         this.generator = generator;
         this.gameMapController = gameMapController;
+        this.gameModel = gameModel;
         this.mapContext = mapContext;
     }
 
@@ -40,6 +44,6 @@ public class DisasterNode implements MenuNode {
     public void actionPerformed(java.awt.event.ActionEvent e) {
         //TODO: Viewと連携する.
         gameMapController.setSelectedEntityGenerator(generator);
-        gameMapController.setActionOnClick(new ActionDisasterHandler());
+        gameMapController.setActionOnClick(new ActionDisasterHandler(gameModel, gameMapController, mapContext));
     }
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/DisasterNode.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/DisasterNode.java
@@ -11,6 +11,9 @@ import io.github.sasori_256.town_planning.map.controller.GameMapController;
 import io.github.sasori_256.town_planning.map.controller.handler.ActionDisasterHandler;
 import io.github.sasori_256.town_planning.map.model.MapContext;
 
+/**
+ * 災害選択用のメニューノード。
+ */
 public class DisasterNode implements MenuNode {
     private final DisasterType type;
     private final Function<Point2D.Double, Disaster> generator;
@@ -18,6 +21,15 @@ public class DisasterNode implements MenuNode {
     private final GameModel gameModel;
     private final MapContext mapContext;
 
+    /**
+     * 災害ノードを生成する。
+     *
+     * @param disasterType      災害種別
+     * @param generator         災害生成関数
+     * @param gameMapController マップコントローラ
+     * @param gameModel         ゲームモデル
+     * @param mapContext        マップ参照
+     */
     public DisasterNode(DisasterType disasterType, Function<Point2D.Double, Disaster> generator, GameMapController gameMapController,
         GameModel gameModel, MapContext mapContext) {
         this.type = disasterType;
@@ -27,19 +39,28 @@ public class DisasterNode implements MenuNode {
         this.mapContext = mapContext;
     }
 
+    /**
+     * 災害種別を返す。
+     *
+     * @return 災害種別
+     */
     public DisasterType getType() { return type; }
 
+    /** {@inheritDoc} */
     @Override
     public String getName() { return type.getDisplayName(); }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isLeaf() { return true; }
 
+    /** {@inheritDoc} */
     @Override
     public ArrayList<MenuNode> getChildren() {
         throw new UnsupportedOperationException("DisasterNode is a leaf node and has no children.");
     }
 
+    /** {@inheritDoc} */
     @Override
     public void actionPerformed(java.awt.event.ActionEvent e) {
         //TODO: Viewと連携する.

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/MenuNode.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/MenuNode.java
@@ -4,11 +4,29 @@ import java.awt.event.ActionListener;
 import java.util.ArrayList;
 
 /**
- * メニューのノードを表すインターフェース.
- * @implNote MenuNodeはActionListenerを継承しており、メニュー項目が選択されたときの動作を定義できる.
+ * メニューのノードを表すインターフェース。
+ *
+ * @implNote MenuNodeはActionListenerを継承しており、選択時の動作を定義できる。
  */
 public interface MenuNode extends ActionListener {
+    /**
+     * 表示名を返す。
+     *
+     * @return 表示名
+     */
     String getName();
+
+    /**
+     * 末端ノードかどうかを返す。
+     *
+     * @return 末端ならtrue
+     */
     boolean isLeaf();
+
+    /**
+     * 子ノードを返す。
+     *
+     * @return 子ノード一覧
+     */
     ArrayList<MenuNode> getChildren();
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/NodeMenuInitializer.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/NodeMenuInitializer.java
@@ -51,7 +51,7 @@ public class NodeMenuInitializer {
             });
 
             DisasterNode disasterNode = new DisasterNode(type, (point) -> new Disaster(point, type),
-                gameMapController, mapContext);
+                gameMapController, gameModel, mapContext);
             categoryNode.add(disasterNode);
         }
         return root;

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/NodeMenuInitializer.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/controller/NodeMenuInitializer.java
@@ -11,12 +11,17 @@ import io.github.sasori_256.town_planning.entity.model.GameModel;
 import io.github.sasori_256.town_planning.map.controller.GameMapController;
 import io.github.sasori_256.town_planning.map.model.MapContext;
 
+/**
+ * メニューノードを組み立てるユーティリティ。
+ */
 public class NodeMenuInitializer {
     /**
-     * ノードメニューの初期化を行う。創造モードと天災モードの親のrootノードを返す。
-     * @param gameMapController ゲームマップコントローラー
-     * @param gameModel ゲームモデル
-     * @return 創造モードと天災モードの親となるrootのCategoryNode
+     * ノードメニューの初期化を行う。
+     * 創造モードと天災モードの親となるルートノードを返す。
+     *
+     * @param gameMapController ゲームマップコントローラ
+     * @param gameModel         ゲームモデル
+     * @return ルートのCategoryNode
      */
     public static CategoryNode setup(GameMapController gameMapController, GameModel gameModel) {
         CategoryNode root = new CategoryNode("root");

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/Camera.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/Camera.java
@@ -5,6 +5,9 @@ import java.awt.geom.Point2D;
 import io.github.sasori_256.town_planning.common.event.events.MapUpdatedEvent;
 import io.github.sasori_256.town_planning.common.event.EventBus;
 
+/**
+ * 画面表示用のカメラを管理するクラス。
+ */
 public class Camera {
   private double scale;
   private int cellHeight;
@@ -53,35 +56,77 @@ public class Camera {
     this.eventBus = eventBus;
   }
 
+  /**
+   * 現在の拡大率を返す。
+   *
+   * @return 拡大率
+   */
   public double getScale() {
     return scale;
   }
 
+  /**
+   * セルの高さ(ピクセル)を返す。
+   *
+   * @return セルの高さ
+   */
   public int getCellHeight() {
     return cellHeight;
   }
 
+  /**
+   * セルの幅(ピクセル)を返す。
+   *
+   * @return セルの幅
+   */
   public int getCellWidth() {
     return cellWidth;
   }
 
+  /**
+   * 画面オフセットXを返す。
+   *
+   * @return オフセットX
+   */
   public int getOffsetX() {
     return offsetX;
   }
 
+  /**
+   * 画面オフセットYを返す。
+   *
+   * @return オフセットY
+   */
   public int getOffsetY() {
     return offsetY;
   }
 
+  /**
+   * アイソ原点のスクリーン座標を返す。
+   *
+   * @return アイソ原点のスクリーン座標
+   */
   public Point2D.Double getIsoOriginByScreen() {
     return isoOriginByScreen;
   }
 
+  /**
+   * 画面オフセットを設定する。
+   *
+   * @param offsetX オフセットX
+   * @param offsetY オフセットY
+   */
   public void setOffset(int offsetX, int offsetY) {
     this.offsetX = offsetX;
     this.offsetY = offsetY;
   }
 
+  /**
+   * 画面サイズを設定し、内部計算を更新する。
+   *
+   * @param screenWidth  画面幅
+   * @param screenHeight 画面高さ
+   */
   public void setScreenSize(int screenWidth, int screenHeight) {
     this.screenWidth = screenWidth;
     this.screenHeight = screenHeight;
@@ -100,6 +145,9 @@ public class Camera {
     }
   }
 
+  /**
+   * 現在のズームレベルを適用する。
+   */
   public void applyZoomLevel() {
     Point2D.Double centerScreen = new Point2D.Double(this.screenWidth / 2.0, this.screenHeight / 2.0);
     Point2D.Double centerIso = screenToIso(centerScreen);
@@ -116,6 +164,11 @@ public class Camera {
     this.offsetY = (int) (centerScreen.y - newCenterScreen.y);
   }
 
+  /**
+   * 拡大率を設定する。
+   *
+   * @param scale 拡大率
+   */
   public void setScale(double scale) {
     this.zoomLevel = Math.clamp((int) Math.round(scale / ZOOM_STEP), MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL);
     applyZoomLevel();
@@ -167,6 +220,12 @@ public class Camera {
     return 0 <= centerIso.x && centerIso.x <= this.mapWidth - 1 && 0 <= centerIso.y && centerIso.y <= this.mapHeight - 1;
   }
 
+  /**
+   * 画面を平行移動する。
+   *
+   * @param dx 移動量X
+   * @param dy 移動量Y
+   */
   public void pan(int dx, int dy) {
     if (isValidOffset(dx, dy)){
       this.offsetX += dx;
@@ -177,22 +236,37 @@ public class Camera {
   }
 
   // TODO: カメラ移動を滑らかにする
+  /**
+   * 上方向へ移動する。
+   */
   public void moveUp() {
     pan(0, 10);
   }
 
+  /**
+   * 下方向へ移動する。
+   */
   public void moveDown() {
     pan(0, -10);
   }
 
+  /**
+   * 左方向へ移動する。
+   */
   public void moveLeft() {
     pan(10, 0);
   }
 
+  /**
+   * 右方向へ移動する。
+   */
   public void moveRight() {
     pan(-10, 0);
   }
 
+  /**
+   * ズームインする。
+   */
   public void zoomIn() {
     if (this.zoomLevel < MAX_ZOOM_LEVEL){
       this.zoomLevel += 1;
@@ -202,6 +276,9 @@ public class Camera {
     }
   }
 
+  /**
+   * ズームアウトする。
+   */
   public void zoomOut() {
     if (this.zoomLevel > MIN_ZOOM_LEVEL){
       this.zoomLevel -= 1;

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/building/Building.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/building/Building.java
@@ -19,6 +19,12 @@ public class Building extends BaseGameEntity {
   private int originY;
   private double animationElapsedSeconds;
 
+  /**
+   * 建物を生成する。
+   *
+   * @param position     設置位置
+   * @param buildingType 建物種別
+   */
   public Building(Point2D.Double position, BuildingType buildingType) {
     super(position);
     this.type = buildingType;
@@ -43,39 +49,81 @@ public class Building extends BaseGameEntity {
     this.setUpdateStrategy(strategy);
   }
 
+  /**
+   * 建物種別を返す。
+   *
+   * @return 建物種別
+   */
   public BuildingType getType() {
     return this.type;
   }
 
+  /**
+   * 現在の耐久度を返す。
+   *
+   * @return 現在耐久度
+   */
   public int getCurrentDurability() {
     return this.currentDurability;
   }
 
+  /**
+   * 現在の耐久度を設定する。
+   *
+   * @param durability 耐久度
+   */
   public void setCurrentDurability(int durability) {
     this.currentDurability = Math.max(0, Math.min(durability, this.type.getMaxDurability()));
   }
 
+  /**
+   * 現在の住民数を返す。
+   *
+   * @return 住民数
+   */
   public int getCurrentPopulation() {
     return this.currentPopulation;
   }
 
+  /**
+   * 現在の住民数を設定する。
+   *
+   * @param population 住民数
+   */
   public void setCurrentPopulation(int population) {
     this.currentPopulation = Math.max(0, Math.min(population, this.type.getMaxPopulation()));
   }
 
+  /**
+   * 建物の原点Xを返す。
+   *
+   * @return 原点X
+   */
   public int getOriginX() {
     return originX;
   }
 
+  /**
+   * 建物の原点Yを返す。
+   *
+   * @return 原点Y
+   */
   public int getOriginY() {
     return originY;
   }
 
+  /**
+   * 建物の原点座標を設定する。
+   *
+   * @param originX 原点X
+   * @param originY 原点Y
+   */
   public void setOrigin(int originX, int originY) {
     this.originX = originX;
     this.originY = originY;
   }
 
+  /** {@inheritDoc} */
   @Override
   public void advanceAnimation(double dt) {
     if (!type.hasAnimation()) {

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/building/Building.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/building/Building.java
@@ -17,6 +17,7 @@ public class Building extends BaseGameEntity {
   private int currentPopulation;
   private int originX;
   private int originY;
+  private double animationElapsedSeconds;
 
   public Building(Point2D.Double position, BuildingType buildingType) {
     super(position);
@@ -25,6 +26,7 @@ public class Building extends BaseGameEntity {
     this.currentPopulation = 0;
     this.originX = (int) Math.round(position.getX());
     this.originY = (int) Math.round(position.getY());
+    this.animationElapsedSeconds = 0.0;
 
     // CompositeUpdateStrategy を使用して、排他アクションと並行エフェクトを管理可能にする
     CompositeUpdateStrategy strategy = new CompositeUpdateStrategy();
@@ -72,5 +74,30 @@ public class Building extends BaseGameEntity {
   public void setOrigin(int originX, int originY) {
     this.originX = originX;
     this.originY = originY;
+  }
+
+  @Override
+  public void advanceAnimation(double dt) {
+    if (!type.hasAnimation()) {
+      return;
+    }
+    if (dt <= 0) {
+      return;
+    }
+    animationElapsedSeconds += dt;
+  }
+
+  /**
+   * 指定タイルのアニメーションフレーム番号を返す。
+   *
+   * @param localX 建物内のX座標
+   * @param localY 建物内のY座標
+   */
+  public int getAnimationFrameIndex(int localX, int localY) {
+    int fps = type.getAnimationFrameRate(localX, localY);
+    if (fps <= 0) {
+      return 0;
+    }
+    return (int) Math.floor(animationElapsedSeconds * fps);
   }
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/building/BuildingType.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/building/BuildingType.java
@@ -228,6 +228,49 @@ public enum BuildingType {
   }
 
   /**
+   * 指定タイルのアニメーション名を返す。
+   *
+   * @param localX 建物内のX座標
+   * @param localY 建物内のY座標
+   */
+  public String getAnimationName(int localX, int localY) {
+    if (localX < 0 || localY < 0 || localX >= width || localY >= height) {
+      return null;
+    }
+    if (this == PLAZA && localX == 1 && localY == 1) {
+      return "plaza_fountain_center";
+    }
+    return null;
+  }
+
+  /**
+   * 指定タイルのアニメーションフレームレートを返す。
+   *
+   * @param localX 建物内のX座標
+   * @param localY 建物内のY座標
+   */
+  public int getAnimationFrameRate(int localX, int localY) {
+    return getAnimationName(localX, localY) != null ? 6 : 0;
+  }
+
+  /**
+   * 指定タイルのアニメーションがループするかを返す。
+   *
+   * @param localX 建物内のX座標
+   * @param localY 建物内のY座標
+   */
+  public boolean isAnimationLoop(int localX, int localY) {
+    return getAnimationName(localX, localY) != null;
+  }
+
+  /**
+   * アニメーションを持つ建物かを返す。
+   */
+  public boolean hasAnimation() {
+    return this == PLAZA;
+  }
+
+  /**
    * 建設コストを返す。
    */
   public int getCost() {

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/building/BuildingType.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/building/BuildingType.java
@@ -265,6 +265,8 @@ public enum BuildingType {
 
   /**
    * アニメーションを持つ建物かを返す。
+   *
+   * @return アニメーションを持つ場合はtrue
    */
   public boolean hasAnimation() {
     return this == PLAZA;

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/building/strategy/PopulationGrowthEffect.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/building/strategy/PopulationGrowthEffect.java
@@ -33,6 +33,7 @@ public class PopulationGrowthEffect implements GameEffect {
     this.timer = 0.0;
   }
 
+  /** {@inheritDoc} */
   @Override
   public void execute(GameContext context, BaseGameEntity self) {
     if (!(self instanceof Building)) {

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/Disaster.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/Disaster.java
@@ -19,6 +19,10 @@ import io.github.sasori_256.town_planning.entity.model.GameAction;
  */
 public class Disaster extends BaseGameEntity {
   private final DisasterType type;
+  private String animationName;
+  private int animationFrameRate;
+  private boolean animationLoop;
+  private double animationElapsedSeconds;
 
   /**
    * Creates a new disaster entity at the specified position.
@@ -38,6 +42,10 @@ public class Disaster extends BaseGameEntity {
   public Disaster(Point2D.Double position, DisasterType disasterType) {
     super(position);
     this.type = disasterType;
+    this.animationName = disasterType.getImageName();
+    this.animationFrameRate = 6;
+    this.animationLoop = true;
+    this.animationElapsedSeconds = 0.0;
 
     CompositeUpdateStrategy strategy = new CompositeUpdateStrategy();
 
@@ -51,5 +59,57 @@ public class Disaster extends BaseGameEntity {
 
   public DisasterType getType() {
     return this.type;
+  }
+
+  /**
+   * アニメーション名を返す。
+   */
+  public String getAnimationName() {
+    return animationName;
+  }
+
+  /**
+   * アニメーションのフレーム番号を返す。
+   */
+  public int getAnimationFrameIndex() {
+    if (animationFrameRate <= 0) {
+      return 0;
+    }
+    return (int) Math.floor(animationElapsedSeconds * animationFrameRate);
+  }
+
+  /**
+   * アニメーションがループするかを返す。
+   */
+  public boolean isAnimationLoop() {
+    return animationLoop;
+  }
+
+  /**
+   * アニメーション設定を更新する。
+   *
+   * @param name      アニメーション名
+   * @param frameRate フレームレート
+   * @param loop      ループ再生するか
+   * @param reset     進行状態をリセットするか
+   */
+  public void setAnimation(String name, int frameRate, boolean loop, boolean reset) {
+    this.animationName = name;
+    this.animationFrameRate = Math.max(0, frameRate);
+    this.animationLoop = loop;
+    if (reset) {
+      this.animationElapsedSeconds = 0.0;
+    }
+  }
+
+  @Override
+  public void advanceAnimation(double dt) {
+    if (animationName == null || animationFrameRate <= 0) {
+      return;
+    }
+    if (dt <= 0) {
+      return;
+    }
+    animationElapsedSeconds += dt;
   }
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/Disaster.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/Disaster.java
@@ -7,14 +7,12 @@ import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
 import io.github.sasori_256.town_planning.entity.model.GameAction;
 
 /**
- * Represents a disaster entity in the game world.
+ * 災害エンティティを表すクラス。
+ *
  * <p>
- * A {@code Disaster} is a {@link BaseGameEntity} placed at a specific position
- * on the map. Its concrete behavior and effects are defined by the associated
- * {@link DisasterType}, which is responsible for creating the
- * {@link GameAction}
- * that drives the disaster's update logic via a
- * {@link CompositeUpdateStrategy}.
+ * {@code Disaster} はマップ上の特定位置に配置される {@link BaseGameEntity} で、
+ * 具体的な挙動は {@link DisasterType} が生成する {@link GameAction} によって決まる。
+ * アクションは {@link CompositeUpdateStrategy} に設定され、更新処理で実行される。
  * </p>
  */
 public class Disaster extends BaseGameEntity {
@@ -25,19 +23,15 @@ public class Disaster extends BaseGameEntity {
   private double animationElapsedSeconds;
 
   /**
-   * Creates a new disaster entity at the specified position.
+   * 指定位置に災害エンティティを生成する。
+   *
    * <p>
-   * Initializes the disaster by creating a {@link CompositeUpdateStrategy} and
-   * populating it with a {@link GameAction} obtained from the disaster type's
-   * action factory. The {@code position} parameter is passed to the action
-   * factory
-   * to create position-specific disaster behavior.
+   * {@link CompositeUpdateStrategy} を生成し、災害種別のアクションファクトリから
+   * 得た {@link GameAction} を設定する。位置情報はアクション生成に渡される。
    * </p>
    *
-   * @param position     the position where the disaster occurs; used to create
-   *                     the disaster's action via the type's action factory
-   * @param disasterType the type defining the disaster's characteristics and
-   *                     behavior
+   * @param position     発生位置
+   * @param disasterType 災害種別
    */
   public Disaster(Point2D.Double position, DisasterType disasterType) {
     super(position);
@@ -57,6 +51,11 @@ public class Disaster extends BaseGameEntity {
     this.setUpdateStrategy(strategy);
   }
 
+  /**
+   * 災害種別を返す。
+   *
+   * @return 災害種別
+   */
   public DisasterType getType() {
     return this.type;
   }
@@ -102,6 +101,7 @@ public class Disaster extends BaseGameEntity {
     }
   }
 
+  /** {@inheritDoc} */
   @Override
   public void advanceAnimation(double dt) {
     if (animationName == null || animationFrameRate <= 0) {

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/Disaster.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/Disaster.java
@@ -83,6 +83,8 @@ public class Disaster extends BaseGameEntity {
 
   /**
    * アニメーションがループするかを返す。
+   *
+   * @return ループするならtrue
    */
   public boolean isAnimationLoop() {
     return animationLoop;

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/Disaster.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/Disaster.java
@@ -62,6 +62,8 @@ public class Disaster extends BaseGameEntity {
 
   /**
    * アニメーション名を返す。
+   *
+   * @return アニメーション名
    */
   public String getAnimationName() {
     return animationName;

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/Disaster.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/Disaster.java
@@ -71,6 +71,8 @@ public class Disaster extends BaseGameEntity {
 
   /**
    * アニメーションのフレーム番号を返す。
+   *
+   * @return フレーム番号
    */
   public int getAnimationFrameIndex() {
     if (animationFrameRate <= 0) {

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/DisasterType.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/DisasterType.java
@@ -11,7 +11,7 @@ import io.github.sasori_256.town_planning.entity.model.GameAction;
  * 天災の種類定義。
  */
 public enum DisasterType {
-  METEOR("隕石", "meteor", 200, 3, 100, CategoryType.METEOR, (pos, type) -> new MeteorDisasterAction(pos, type)),
+  METEOR("隕石", "loading", 200, 3, 100, CategoryType.METEOR, (pos, type) -> new MeteorDisasterAction(pos, type)),
   PLAGUE("疫病", "plague", 150, 5, 20, CategoryType.PLAGUE);
 
   private final String displayName;

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/DisasterType.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/DisasterType.java
@@ -11,6 +11,7 @@ import io.github.sasori_256.town_planning.entity.model.GameAction;
  * 天災の種類定義。
  */
 public enum DisasterType {
+  // TODO: ローディングのぐるぐるの画像差し替えないとボケすぎる
   METEOR("隕石", "loading", 200, 3, 100, CategoryType.METEOR, (pos, type) -> new MeteorDisasterAction(pos, type)),
   PLAGUE("疫病", "plague", 150, 5, 20, CategoryType.PLAGUE);
 

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/DisasterType.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/DisasterType.java
@@ -48,30 +48,66 @@ public enum DisasterType {
     this(displayName, imageName, cost, radius, damage, category, null);
   }
 
+  /**
+   * 表示名を返す。
+   *
+   * @return 表示名
+   */
   public String getDisplayName() {
     return displayName;
   }
 
+  /**
+   * 画像名を返す。
+   *
+   * @return 画像名
+   */
   public String getImageName() {
     return imageName;
   }
 
+  /**
+   * 発生コストを返す。
+   *
+   * @return コスト
+   */
   public int getCost() {
     return cost;
   }
 
+  /**
+   * 影響範囲の半径を返す。
+   *
+   * @return 半径
+   */
   public int getRadius() {
     return radius;
   }
 
+  /**
+   * 与えるダメージ量を返す。
+   *
+   * @return ダメージ量
+   */
   public int getDamage() {
     return damage;
   }
 
+  /**
+   * カテゴリを返す。
+   *
+   * @return カテゴリ
+   */
   public CategoryType getCategory() {
     return category;
   }
 
+  /**
+   * 目標位置に応じたアクションを生成する。
+   *
+   * @param targetPos 目標位置
+   * @return 生成したアクション。未設定ならnull
+   */
   public GameAction createAction(Point2D.Double targetPos) {
     return actionFactory == null ? null : actionFactory.apply(targetPos, this);
   }

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/BaseGameEntity.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/BaseGameEntity.java
@@ -15,15 +15,25 @@ public abstract class BaseGameEntity implements GameEntity, Animatable, Lifecycl
   protected Point2D.Double position;
 
   // Layer Indices
-  public static final int LAYER_BACKGROUND = 0; // 背景層
-  public static final int LAYER_GROUND = 5; // 地面層
-  public static final int LAYER_DEFAULT = 10; // 通常のオブジェクト層
-  public static final int LAYER_AID = 20; // 空中オブジェクト層
-  public static final int LAYER_UI = 100; // UI層
+  /** 背景層。 */
+  public static final int LAYER_BACKGROUND = 0;
+  /** 地面層。 */
+  public static final int LAYER_GROUND = 5;
+  /** 通常のオブジェクト層。 */
+  public static final int LAYER_DEFAULT = 10;
+  /** 空中オブジェクト層。 */
+  public static final int LAYER_AID = 20;
+  /** UI層。 */
+  public static final int LAYER_UI = 100;
 
   // Strategies
   private UpdateStrategy updateStrategy;
 
+  /**
+   * 位置を指定してエンティティを生成する。
+   *
+   * @param position 初期位置
+   */
   public BaseGameEntity(Point2D.Double position) {
     this.layerIndex = LAYER_DEFAULT;
     this.position = position;
@@ -32,47 +42,60 @@ public abstract class BaseGameEntity implements GameEntity, Animatable, Lifecycl
     };
   }
 
+  /** {@inheritDoc} */
   @Override
   public int getLayerIndex() {
     return this.layerIndex;
   }
 
+  /** {@inheritDoc} */
   @Override
   public void setLayerIndex(int layerIndex) {
     this.layerIndex = layerIndex;
   }
 
+  /** {@inheritDoc} */
   @Override
   public Point2D.Double getPosition() {
     return position;
   }
 
+  /** {@inheritDoc} */
   @Override
   public void setPosition(Point2D.Double position) {
     this.position = position;
   }
 
+  /** {@inheritDoc} */
   @Override
   public void setUpdateStrategy(UpdateStrategy updateStrategy) {
     this.updateStrategy = updateStrategy;
   }
 
+  /** {@inheritDoc} */
   @Override
   public void onSpawn(GameContext context) {
     // デフォルトでは何もしない (必要に応じてオーバーライド)
   }
 
+  /** {@inheritDoc} */
   @Override
   public void onRemove(GameContext context) {
     // デフォルトでは何もしない (必要に応じてオーバーライド)
   }
 
+  /**
+   * エンティティの更新処理を行う。
+   *
+   * @param context ゲームコンテキスト
+   */
   public void update(GameContext context) {
     if (updateStrategy != null) {
       updateStrategy.update(context, this);
     }
   }
 
+  /** {@inheritDoc} */
   @Override
   public void advanceAnimation(double dt) {
     // No-op by default

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/CategoryType.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/CategoryType.java
@@ -1,5 +1,8 @@
 package io.github.sasori_256.town_planning.entity.model;
 
+/**
+ * 建物・災害のカテゴリを表す列挙型。
+ */
 public enum CategoryType {
   RESIDENTIAL("住居"),
   RELIGIOUS("宗教施設"),
@@ -15,6 +18,11 @@ public enum CategoryType {
     this.displayName = displayName;
   }
 
+  /**
+   * 表示名を返す。
+   *
+   * @return 表示名
+   */
   public String getDisplayName() {
     return displayName;
   }

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameContext.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameContext.java
@@ -25,16 +25,46 @@ import java.util.stream.Stream;
  * DI (Dependency Injection) のような役割を果たす。
  */
 public interface GameContext {
+  /**
+   * イベントバスを返す。
+   *
+   * @return イベントバス
+   */
   EventBus getEventBus();
 
+  /**
+   * マップを返す。
+   *
+   * @return マップ
+   */
   GameMap getMap();
 
+  /**
+   * 建物エンティティのストリームを返す。
+   *
+   * @return 建物エンティティのストリーム
+   */
   Stream<Building> getBuildingEntities();
 
+  /**
+   * 住民エンティティのストリームを返す。
+   *
+   * @return 住民エンティティのストリーム
+   */
   Stream<Resident> getResidentEntities();
 
+  /**
+   * 災害エンティティのストリームを返す。
+   *
+   * @return 災害エンティティのストリーム
+   */
   Stream<Disaster> getDisasterEntities();
 
+  /**
+   * 前フレームからの経過時間(秒)を返す。
+   *
+   * @return 経過時間(秒)
+   */
   double getDeltaTime(); // 前フレームからの経過時間（秒）
 
   /**
@@ -59,8 +89,20 @@ public interface GameContext {
 
   // Entity Lifecycle
 
+  /**
+   * エンティティを生成してゲームに追加する。
+   *
+   * @param entity 追加するエンティティ
+   * @param <T>    エンティティ型
+   */
   <T extends BaseGameEntity> void spawnEntity(T entity);
 
+  /**
+   * エンティティをゲームから削除する。
+   *
+   * @param entity 削除するエンティティ
+   * @param <T>    エンティティ型
+   */
   <T extends BaseGameEntity> void removeEntity(T entity);
 
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/ResidentState.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/ResidentState.java
@@ -6,16 +6,25 @@ package io.github.sasori_256.town_planning.entity.resident;
 public enum ResidentState {
   /** 家にいて非表示の状態。 */
   AT_HOME,
+  /** 待機中。 */
   IDLE,
+  /** 作業中。 */
   WORKING,
+  /** 休憩中。 */
   RELAXING,
+  /** 移動中。 */
   TRAVELING,
   /** 引っ越し中。 */
   RELOCATING,
+  /** 睡眠中。 */
   SLEEPING,
+  /** 食事中。 */
   EATING,
+  /** 帰宅中。 */
   RETURNING_HOME,
-  PANICKING, // 天災などの緊急事態
+  /** 天災などの緊急事態。 */
+  PANICKING,
+  /** 死亡状態。 */
   DEAD;
 
   ResidentState() {

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/DestinationMoveAction.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/DestinationMoveAction.java
@@ -116,6 +116,7 @@ public class DestinationMoveAction implements GameAction {
     return new Point2D.Double(destination.getX(), destination.getY());
   }
 
+  /** {@inheritDoc} */
   @Override
   public void execute(GameContext context, BaseGameEntity self) {
     lastStatus = MoveStatus.IDLE;

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/ResidentLifeCycleEffect.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/ResidentLifeCycleEffect.java
@@ -12,6 +12,7 @@ import io.github.sasori_256.town_planning.entity.resident.ResidentState;
  * 住民のライフサイクル（加齢、死亡）を管理するEffect。
  */
 public class ResidentLifeCycleEffect implements UpdateStrategy, GameEffect {
+  /** {@inheritDoc} */
   @Override
   public void update(GameContext context, BaseGameEntity self) {
     if (!(self instanceof Resident)) {
@@ -43,7 +44,7 @@ public class ResidentLifeCycleEffect implements UpdateStrategy, GameEffect {
 
   private void die(GameContext context, BaseGameEntity self) {
     Resident resident = (Resident) self;
-    resident.setState(ResidentState.DEAD);
+    resident.markDead();
 
     // 死亡イベント発行
     context.getEventBus().publish(new ResidentDiedEvent(resident));

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/controller/GameMapController.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/controller/GameMapController.java
@@ -20,6 +20,9 @@ import io.github.sasori_256.town_planning.entity.Camera;
 import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
 import io.github.sasori_256.town_planning.map.controller.handler.*;
 
+/**
+ * マップ操作に関する入力イベントを扱うコントローラ。
+ */
 public class GameMapController implements MouseListener, MouseMotionListener, KeyListener, MouseWheelListener {
   private Camera camera;
   private final ReadWriteLock stateLock;
@@ -27,6 +30,12 @@ public class GameMapController implements MouseListener, MouseMotionListener, Ke
   private Function<Point2D.Double, ? extends BaseGameEntity> selectedEntityGenerator;
   private Point previousMiddleMousePos;
 
+  /**
+   * マップコントローラを生成する。
+   *
+   * @param camera    カメラ
+   * @param stateLock 状態ロック
+   */
   public GameMapController(Camera camera, ReadWriteLock stateLock) {
     this.camera = camera;
     this.stateLock = stateLock;
@@ -36,17 +45,27 @@ public class GameMapController implements MouseListener, MouseMotionListener, Ke
 
   /**
    * GameMap上でのクリック時の動作を設定する
-   * 
+   *
    * @param action
    */
   public void setActionOnClick(BiConsumer<Point2D.Double, Function<Point2D.Double, ? extends BaseGameEntity>> action) {
     this.actionOnClick = action;
   }
 
+  /**
+   * 選択中のエンティティ生成関数を設定する。
+   *
+   * @param entityGenerator 生成関数
+   */
   public void setSelectedEntityGenerator(Function<Point2D.Double, ? extends BaseGameEntity> entityGenerator) {
     this.selectedEntityGenerator = entityGenerator;
   }
 
+  /**
+   * クリック時の処理を行う。
+   *
+   * @param e マウスイベント
+   */
   @Override
   public void mouseClicked(MouseEvent e) {
     if (SwingUtilities.isLeftMouseButton(e)) {
@@ -61,6 +80,11 @@ public class GameMapController implements MouseListener, MouseMotionListener, Ke
     }
   }
 
+  /**
+   * マウス押下時の処理を行う。
+   *
+   * @param e マウスイベント
+   */
   @Override
   public void mousePressed(MouseEvent e) {
     if (SwingUtilities.isMiddleMouseButton(e)) {
@@ -68,6 +92,11 @@ public class GameMapController implements MouseListener, MouseMotionListener, Ke
     }
   }
 
+  /**
+   * マウス解放時の処理を行う。
+   *
+   * @param e マウスイベント
+   */
   @Override
   public void mouseReleased(MouseEvent e) {
     if (SwingUtilities.isMiddleMouseButton(e)) {
@@ -75,6 +104,11 @@ public class GameMapController implements MouseListener, MouseMotionListener, Ke
     }
   }
 
+  /**
+   * マウスドラッグ時の処理を行う。
+   *
+   * @param e マウスイベント
+   */
   @Override
   public void mouseDragged(MouseEvent e) {
     if (SwingUtilities.isMiddleMouseButton(e) && previousMiddleMousePos != null) {
@@ -86,6 +120,11 @@ public class GameMapController implements MouseListener, MouseMotionListener, Ke
     }
   }
 
+  /**
+   * マウスホイール操作時の処理を行う。
+   *
+   * @param e マウスイベント
+   */
   @Override
   public void mouseWheelMoved(MouseWheelEvent e) {
     int notches = e.getWheelRotation();
@@ -96,18 +135,38 @@ public class GameMapController implements MouseListener, MouseMotionListener, Ke
     }
   }
 
+  /**
+   * マウスが領域に入った際の処理を行う。
+   *
+   * @param e マウスイベント
+   */
   @Override
   public void mouseEntered(MouseEvent e) {
   }
 
+  /**
+   * マウスが領域から出た際の処理を行う。
+   *
+   * @param e マウスイベント
+   */
   @Override
   public void mouseExited(MouseEvent e) {
   }
 
+  /**
+   * マウス移動時の処理を行う。
+   *
+   * @param e マウスイベント
+   */
   @Override
   public void mouseMoved(MouseEvent e) {
   }
 
+  /**
+   * キー押下時の処理を行う。
+   *
+   * @param e キーイベント
+   */
   @Override
   public void keyPressed(KeyEvent e) {
     int k = e.getKeyCode();
@@ -129,10 +188,20 @@ public class GameMapController implements MouseListener, MouseMotionListener, Ke
     }
   }
 
+  /**
+   * キー解放時の処理を行う。
+   *
+   * @param e キーイベント
+   */
   @Override
   public void keyReleased(KeyEvent e) {
   }
 
+  /**
+   * キー入力時の処理を行う。
+   *
+   * @param e キーイベント
+   */
   @Override
   public void keyTyped(KeyEvent e) {
   }

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/ActionDisasterHandler.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/ActionDisasterHandler.java
@@ -9,12 +9,22 @@ import io.github.sasori_256.town_planning.entity.model.GameModel;
 import io.github.sasori_256.town_planning.map.controller.GameMapController;
 import io.github.sasori_256.town_planning.map.model.MapContext;
 
+/**
+ * クリック位置に災害を発生させるハンドラ。
+ */
 public class ActionDisasterHandler
     implements BiConsumer<Point2D.Double, Function<Point2D.Double, ? extends BaseGameEntity>> {
   private final GameModel gameModel;
   private final GameMapController gameMapController;
   private final MapContext mapContext;
 
+  /**
+   * 災害発生ハンドラを生成する。
+   *
+   * @param gameModel         ゲームモデル
+   * @param gameMapController マップコントローラ
+   * @param mapContext        マップ参照
+   */
   public ActionDisasterHandler(GameModel gameModel, GameMapController gameMapController,
       MapContext mapContext) {
     this.gameModel = gameModel;
@@ -23,6 +33,12 @@ public class ActionDisasterHandler
   }
 
   @Override
+  /**
+   * クリック位置に災害発生を試みる。
+   *
+   * @param isoPoint        クリック位置(アイソメトリック座標)
+   * @param entityGenerator 生成関数
+   */
   public void accept(Point2D.Double isoPoint, Function<Point2D.Double, ? extends BaseGameEntity> entityGenerator) {
     if (entityGenerator == null) {
       return;

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/ActionDisasterHandler.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/ActionDisasterHandler.java
@@ -3,15 +3,42 @@ package io.github.sasori_256.town_planning.map.controller.handler;
 import java.awt.geom.Point2D;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-
+import io.github.sasori_256.town_planning.entity.disaster.Disaster;
 import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
+import io.github.sasori_256.town_planning.entity.model.GameModel;
+import io.github.sasori_256.town_planning.map.controller.GameMapController;
+import io.github.sasori_256.town_planning.map.model.MapContext;
 
 public class ActionDisasterHandler
     implements BiConsumer<Point2D.Double, Function<Point2D.Double, ? extends BaseGameEntity>> {
-  @Override
-  public void accept(Point2D.Double isoPoint, Function<Point2D.Double, ? extends BaseGameEntity> entityGenerator) {
-    // TODO:
-    System.out.println("Action Disaster at: (" + isoPoint.x + ", " + isoPoint.y + ")");
+  private final GameModel gameModel;
+  private final GameMapController gameMapController;
+  private final MapContext mapContext;
+
+  public ActionDisasterHandler(GameModel gameModel, GameMapController gameMapController,
+      MapContext mapContext) {
+    this.gameModel = gameModel;
+    this.gameMapController = gameMapController;
+    this.mapContext = mapContext;
   }
 
+  @Override
+  public void accept(Point2D.Double isoPoint, Function<Point2D.Double, ? extends BaseGameEntity> entityGenerator) {
+    if (entityGenerator == null) {
+      return;
+    }
+    Point2D.Double roundedPoint = new Point2D.Double(Math.round(isoPoint.x), Math.round(isoPoint.y));
+    if (mapContext != null && !mapContext.isValidPosition(roundedPoint)) {
+      System.err.println("Error: Invalid disaster position " + roundedPoint);
+      return;
+    }
+    BaseGameEntity entity = entityGenerator.apply(roundedPoint);
+    if (entity instanceof Disaster disaster) {
+      gameModel.spawnEntity(disaster);
+    } else {
+      System.err.println("Error: Trying to spawn a disaster that is not a Disaster.");
+    }
+    gameMapController.setSelectedEntityGenerator((point) -> null);
+    gameMapController.setActionOnClick(new ClickGameMapHandler());
+  }
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/ActionDisasterHandler.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/ActionDisasterHandler.java
@@ -32,13 +32,13 @@ public class ActionDisasterHandler
     this.mapContext = mapContext;
   }
 
-  @Override
   /**
    * クリック位置に災害発生を試みる。
    *
    * @param isoPoint        クリック位置(アイソメトリック座標)
    * @param entityGenerator 生成関数
    */
+  @Override
   public void accept(Point2D.Double isoPoint, Function<Point2D.Double, ? extends BaseGameEntity> entityGenerator) {
     if (entityGenerator == null) {
       return;

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/ClickGameMapHandler.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/ClickGameMapHandler.java
@@ -6,8 +6,17 @@ import java.util.function.Function;
 
 import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
 
+/**
+ * クリック時のデフォルト動作を行うハンドラ。
+ */
 public class ClickGameMapHandler
     implements BiConsumer<Point2D.Double, Function<Point2D.Double, ? extends BaseGameEntity>> {
+  /**
+   * クリック位置の処理を行う。
+   *
+   * @param isoPoint        クリック位置(アイソメトリック座標)
+   * @param entityGenerator 生成関数
+   */
   @Override
   public void accept(Point2D.Double isoPoint, Function<Point2D.Double, ? extends BaseGameEntity> entityGenerator) {
     // TODO:

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/PlaceBuildingHandler.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/PlaceBuildingHandler.java
@@ -27,13 +27,13 @@ public class PlaceBuildingHandler
     this.gameMapController = gameMapController;
   }
 
-  @Override
   /**
    * クリック位置に対して建物配置を試みる。
    *
    * @param isoPoint        クリック位置(アイソメトリック座標)
    * @param entityGenerator 生成関数
    */
+  @Override
   public void accept(Point2D.Double isoPoint, Function<Point2D.Double, ? extends BaseGameEntity> entityGenerator) {
     System.out.println("Placing building at: " + isoPoint);
     Point2D.Double roundedPoint = new Point2D.Double(Math.round(isoPoint.x), Math.round(isoPoint.y));

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/PlaceBuildingHandler.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/controller/handler/PlaceBuildingHandler.java
@@ -8,17 +8,32 @@ import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
 import io.github.sasori_256.town_planning.entity.model.GameModel;
 import io.github.sasori_256.town_planning.map.controller.GameMapController;
 
+/**
+ * クリック位置に建物を配置するハンドラ。
+ */
 public class PlaceBuildingHandler
     implements BiConsumer<Point2D.Double, Function<Point2D.Double, ? extends BaseGameEntity>> {
   private GameModel gameModel;
   private GameMapController gameMapController;
 
+  /**
+   * 配置ハンドラを生成する。
+   *
+   * @param gameModel         ゲームモデル
+   * @param gameMapController マップコントローラ
+   */
   public PlaceBuildingHandler(GameModel gameModel, GameMapController gameMapController) {
     this.gameModel = gameModel;
     this.gameMapController = gameMapController;
   }
 
   @Override
+  /**
+   * クリック位置に対して建物配置を試みる。
+   *
+   * @param isoPoint        クリック位置(アイソメトリック座標)
+   * @param entityGenerator 生成関数
+   */
   public void accept(Point2D.Double isoPoint, Function<Point2D.Double, ? extends BaseGameEntity> entityGenerator) {
     System.out.println("Placing building at: " + isoPoint);
     Point2D.Double roundedPoint = new Point2D.Double(Math.round(isoPoint.x), Math.round(isoPoint.y));

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/model/GameMap.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/model/GameMap.java
@@ -6,6 +6,9 @@ import io.github.sasori_256.town_planning.common.event.events.MapUpdatedEvent;
 import io.github.sasori_256.town_planning.entity.building.Building;
 import io.github.sasori_256.town_planning.entity.building.BuildingType;
 
+/**
+ * ゲーム内のマップ状態を保持する実装。
+ */
 public class GameMap implements MapContext {
   private final int width;
   private final int height;
@@ -13,9 +16,11 @@ public class GameMap implements MapContext {
   private final EventBus eventBus;
 
   /**
-   * @param width
-   * @param height
-   * @param eventBus
+   * マップを生成する。
+   *
+   * @param width    横幅(セル数)
+   * @param height   縦幅(セル数)
+   * @param eventBus イベントバス
    */
   public GameMap(int width, int height, EventBus eventBus) {
     this.width = width;
@@ -31,6 +36,7 @@ public class GameMap implements MapContext {
     }
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean isValidPosition(Point2D.Double pos) {
     double x = pos.getX(); // 中心基準
@@ -39,6 +45,7 @@ public class GameMap implements MapContext {
         && y >= -0.5 && y < this.height - 0.5;
   }
 
+  /** {@inheritDoc} */
   @Override
   public MapCell getCell(Point2D.Double pos) {
     if (!isValidPosition(pos)) {
@@ -49,6 +56,7 @@ public class GameMap implements MapContext {
     return cells[(int) pos.getY()][(int) pos.getX()];
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean placeBuilding(Point2D.Double pos, Building building) {
     if (building == null) {
@@ -104,6 +112,7 @@ public class GameMap implements MapContext {
     return true;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean removeBuilding(Point2D.Double pos) {
     int anchorX = (int) Math.round(pos.getX());
@@ -145,11 +154,13 @@ public class GameMap implements MapContext {
     return true;
   }
 
+  /** {@inheritDoc} */
   @Override
   public int getWidth() {
     return width;
   }
 
+  /** {@inheritDoc} */
   @Override
   public int getHeight() {
     return height;

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/model/MapCell.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/model/MapCell.java
@@ -6,6 +6,9 @@ import org.jspecify.annotations.Nullable;
 
 import io.github.sasori_256.town_planning.entity.building.Building;
 
+/**
+ * マップ上の1セルの状態を保持するクラス。
+ */
 public class MapCell {
   private final Point2D.Double position;
   private Terrain terrain;
@@ -16,6 +19,12 @@ public class MapCell {
   private int localX;
   private int localY;
 
+  /**
+   * セルを生成する。
+   *
+   * @param position    セル座標
+   * @param initTerrain 初期地形
+   */
   public MapCell(Point2D.Double position, Terrain initTerrain) {
     this.position = position;
     this.terrain = initTerrain;
@@ -25,41 +34,87 @@ public class MapCell {
     this.localY = 0;
   }
 
+  /**
+   * セル座標を返す。
+   *
+   * @return セル座標
+   */
   public Point2D.Double getPosition() {
     return position;
   }
 
+  /**
+   * 地形を返す。
+   *
+   * @return 地形
+   */
   public Terrain getTerrain() {
     return terrain;
   }
 
+  /**
+   * 地形を更新する。
+   *
+   * @param terrain 設定する地形
+   * @return 更新できた場合はtrue
+   */
   public boolean setTerrain(Terrain terrain) {
     this.terrain = terrain;
     return true;
   }
 
+  /**
+   * 建物を返す。
+   *
+   * @return 建物。未配置ならnull
+   */
   public Building getBuilding() {
     return building;
   }
 
+  /**
+   * 建物内のローカルX座標を返す。
+   *
+   * @return ローカルX
+   */
   public int getLocalX() {
     return localX;
   }
 
+  /**
+   * 建物内のローカルY座標を返す。
+   *
+   * @return ローカルY
+   */
   public int getLocalY() {
     return localY;
   }
 
+  /**
+   * 建物で占有されているかを返す。
+   *
+   * @return 建物がある場合はtrue
+   */
   public boolean isOccupied() {
     return building != null;
   }
 
+  /**
+   * 建物とローカル座標を設定する。
+   *
+   * @param building 建物
+   * @param localX   建物内のローカルX
+   * @param localY   建物内のローカルY
+   */
   public void setBuilding(Building building, int localX, int localY) {
     this.building = building;
     this.localX = localX;
     this.localY = localY;
   }
 
+  /**
+   * 建物情報をクリアする。
+   */
   public void clearBuilding() {
     this.building = null;
     this.localX = 0;
@@ -88,6 +143,11 @@ public class MapCell {
     return building.getType().isWalkable(localX, localY);
   }
 
+  /**
+   * 移動コストを返す。
+   *
+   * @return 移動コスト
+   */
   public int getMoveCost() {
     if (building == null) {
       return terrain.getMoveCost();

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/model/MapContext.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/model/MapContext.java
@@ -4,6 +4,9 @@ import java.awt.geom.Point2D;
 
 import io.github.sasori_256.town_planning.entity.building.Building;
 
+/**
+ * マップ操作に必要な最小限の読み書きAPIを定義する。
+ */
 public interface MapContext {
   /**
    * マップ上のセルの位置が有効かどうかを確認する。
@@ -34,7 +37,17 @@ public interface MapContext {
    */
   public boolean removeBuilding(Point2D.Double position);
 
+  /**
+   * マップの横幅(セル数)を返す。
+   *
+   * @return 横幅
+   */
   public int getWidth();
 
+  /**
+   * マップの縦幅(セル数)を返す。
+   *
+   * @return 縦幅
+   */
   public int getHeight();
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/model/Terrain.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/model/Terrain.java
@@ -1,13 +1,39 @@
 package io.github.sasori_256.town_planning.map.model;
 
+/**
+ * 地形の属性を表すインターフェース。
+ */
 public interface Terrain {
+  /**
+   * 表示名を返す。
+   *
+   * @return 表示名
+   */
   String getDisplayName();
 
+  /**
+   * 住民が歩行可能かを返す。
+   *
+   * @return 歩行可能ならtrue
+   */
   boolean isWalkable();
 
+  /**
+   * 建築可能かを返す。
+   *
+   * @return 建築可能ならtrue
+   */
   boolean isBuildable();
 
+  /**
+   * 移動コストを返す。
+   *
+   * @return 移動コスト
+   */
   int getMoveCost();
 
+  /**
+   * 地形の描画処理を行う。
+   */
   void draw();
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/model/TerrainType.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/model/TerrainType.java
@@ -1,5 +1,8 @@
 package io.github.sasori_256.town_planning.map.model;
 
+/**
+ * 地形の種別を表す列挙型。
+ */
 public enum TerrainType implements Terrain {
   GRASS("Grass", true, true, 2),
   WATER("Water", false, false, 1_000_000),
@@ -17,26 +20,31 @@ public enum TerrainType implements Terrain {
     this.moveCost = moveCost;
   }
 
+  /** {@inheritDoc} */
   @Override
   public String getDisplayName() {
     return displayName;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean isWalkable() {
     return walkable;
   }
 
+  /** {@inheritDoc} */
   @Override
   public boolean isBuildable() {
     return buildable;
   }
 
+  /** {@inheritDoc} */
   @Override
   public int getMoveCost() {
     return moveCost;
   }
 
+  /** {@inheritDoc} */
   @Override
   public void draw() {
   }


### PR DESCRIPTION
## 概要
- AnimationManagerをGameLoopに連携し、建物/災害のアニメ表示を有効化
- 隕石の発生〜着弾演出と住民死亡アニメを追加
- 公開APIのJavadocを日本語化・補完

## テスト
- 正しく死亡アニメーションを再生できた