### PR TITLE
feat/154-generate-townHall-on-initialization

### DIFF
--- a/app/src/main/java/io/github/sasori_256/town_planning/App.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/App.java
@@ -1,17 +1,13 @@
 package io.github.sasori_256.town_planning;
 
-import java.awt.geom.Point2D;
 import java.util.concurrent.locks.ReadWriteLock;
+
 import javax.swing.SwingUtilities;
+
 import io.github.sasori_256.town_planning.common.event.EventBus;
 import io.github.sasori_256.town_planning.common.ui.GameWindow;
 import io.github.sasori_256.town_planning.entity.Camera;
-import io.github.sasori_256.town_planning.entity.building.Building;
-import io.github.sasori_256.town_planning.entity.building.BuildingType;
 import io.github.sasori_256.town_planning.entity.model.GameModel;
-import io.github.sasori_256.town_planning.entity.resident.Resident;
-import io.github.sasori_256.town_planning.entity.resident.ResidentState;
-import io.github.sasori_256.town_planning.entity.resident.ResidentType;
 import io.github.sasori_256.town_planning.map.controller.GameMapController;
 import io.github.sasori_256.town_planning.map.model.GameMap;
 
@@ -34,18 +30,6 @@ public class App {
     EventBus eventBus = new EventBus();
     GameModel gameModel = new GameModel(MAP_WIDTH, MAP_HEIGHT, SEED, eventBus);
     GameMap gameMap = gameModel.getGameMap();
-    Point2D.Double homePos = new Point2D.Double(0, 0);
-
-    // テスト用に(0, 0)に2人住んでいる家を生成
-    Building home = new Building(homePos, BuildingType.RED_ROOFED_HOUSE);
-    if (gameMap.placeBuilding(homePos, home)) {
-      home.setCurrentPopulation(2);
-      gameModel.spawnEntity(home);
-      gameModel.spawnEntity(new Resident(new Point2D.Double(homePos.getX(), homePos.getY()),
-          ResidentType.CITIZEN, ResidentState.AT_HOME, homePos));
-      gameModel.spawnEntity(new Resident(new Point2D.Double(homePos.getX(), homePos.getY()),
-          ResidentType.CITIZEN, ResidentState.AT_HOME, homePos));
-    }
 
     Camera camera = new Camera(1, WIDTH, HEIGHT, MAP_WIDTH, MAP_HEIGHT, eventBus);
     ReadWriteLock stateLock = gameModel.getStateLock();

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
@@ -1,6 +1,7 @@
 package io.github.sasori_256.town_planning.entity.model;
 
 import java.awt.geom.Point2D;
+import java.util.Random;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -15,7 +16,6 @@ import io.github.sasori_256.town_planning.common.event.EventBus;
 import io.github.sasori_256.town_planning.entity.building.Building;
 import io.github.sasori_256.town_planning.entity.building.BuildingType;
 import io.github.sasori_256.town_planning.entity.disaster.Disaster;
-import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
 import io.github.sasori_256.town_planning.entity.model.manager.BuildingManager;
 import io.github.sasori_256.town_planning.entity.model.manager.EntityManager;
 import io.github.sasori_256.town_planning.entity.model.manager.PopulationManager;
@@ -24,6 +24,7 @@ import io.github.sasori_256.town_planning.entity.model.manager.SoulManager;
 import io.github.sasori_256.town_planning.entity.model.manager.TimeManager;
 import io.github.sasori_256.town_planning.entity.resident.Resident;
 import io.github.sasori_256.town_planning.map.model.GameMap;
+import io.github.sasori_256.town_planning.map.model.TerrainType;
 
 /**
  * ゲームの環境情報を管理するモデルクラス。
@@ -77,6 +78,7 @@ public class GameModel implements GameContext, SimulationStep {
   public GameModel(int mapWidth, int mapHeight, long seed, EventBus eventBus) {
     this.eventBus = eventBus;
     this.gameMap = new GameMap(mapWidth, mapHeight, seed, eventBus);
+    GenerateTownHall(seed); // マップ中央付近に町の中心を生成
 
     this.entityManager = new EntityManager(eventBus, stateLock);
     this.soulManager = new SoulManager(eventBus, stateLock, entityManager, INITIAL_SOUL);
@@ -419,4 +421,67 @@ public class GameModel implements GameContext, SimulationStep {
       }
     });
   }
+  
+  /**
+   * マップ中央付近に町の中心を生成する。
+   * 
+   * @param seed シード値
+   */
+  private void GenerateTownHall(long seed) {
+    int width = gameMap.getWidth();
+    int height = gameMap.getHeight();
+    int centerX = width / 2;
+    int centerY = height / 2;
+    Random rand = new Random(seed);
+    final int MAX_LOOP_COUNT = 10;
+    // マップの中央を基準に正規分布に従ってオフセットを決定
+    // 配置しようとした位置が海だった場合はseedを変えて再試行する
+    int offsetX, offsetY, townHallX = width/2, townHallY = height/2, loopCount = 0;
+    boolean foundProperPos = false; // 陸地が見つかったかどうか
+    while (loopCount < MAX_LOOP_COUNT) {
+      offsetX = (int) Math.round(rand.nextGaussian() * width / 10);
+      offsetY = (int) Math.round(rand.nextGaussian() * height / 10);
+      townHallX = centerX + offsetX;
+      townHallY = centerY + offsetY;
+      if (gameMap.getCell(new Point2D.Double(townHallX, townHallY)).getTerrain() != TerrainType.WATER) {
+        foundProperPos = true;
+        break;
+      }
+      loopCount++;
+      rand.setSeed(seed + loopCount); // townHallPosが海だった場合はシードを変えて再試行
+    }
+    // 10回試行しても陸地が見つからない場合はマップを全探索し、最初に見つけた陸地に配置する
+    for (int y = 0; y < height && !foundProperPos; y++) {
+      for (int x = 0; x < width && !foundProperPos; x++) {
+        if (gameMap.getCell(new Point2D.Double(x, y)).getTerrain() != TerrainType.WATER) {
+          townHallX = x;
+          townHallY = y;
+          foundProperPos = true;
+          System.out.println("Warning: マップ中央付近に適切な陸地が見つかりませんでした。最初に見つかった陸地に町の中心を配置します。");
+        }
+      }
+    }
+    if (!foundProperPos) {
+      // 陸地が一つもないマップの場合は強制的に中央に配置
+      System.out.println("Warning: マップに陸地が存在しません。町の中心をマップ中央に強制配置します。");
+      townHallX = centerX;
+      townHallY = centerY;
+    }
+
+    // TODO: 町の中心として一旦青い屋根の家を使用　正しい建物タイプに変更する必要あり
+    // TODO: 住民の初期スポーンもここで行うはずなのだが、(続)
+    // Exception in thread "main" java.lang.NullPointerException: Cannot invoke "io.github.sasori_256.town_planning.entity.model.manager.EntityManager.spawnEntity(io.github.sasori_256.town_planning.entity.model.BaseGameEntity, io.github.sasori_256.town_planning.entity.model.GameContext)" because "this.entityManager" is null
+    // エラーが発生するためコメントアウト中
+    Point2D.Double townHallPos = new Point2D.Double(townHallX, townHallY);
+    Building townHall = new Building(townHallPos, BuildingType.BLUE_ROOFED_HOUSE);
+    if (gameMap.placeBuilding(townHallPos, townHall)) {
+      townHall.setCurrentPopulation(2);
+      // spawnEntity(townHall);
+      // spawnEntity(new Resident(new Point2D.Double(townHallPos.y, townHallPos.x),
+          // ResidentType.CITIZEN, ResidentState.AT_HOME, townHallPos));
+      // spawnEntity(new Resident(new Point2D.Double(townHallPos.y, townHallPos.x),
+          // ResidentType.CITIZEN, ResidentState.AT_HOME, townHallPos));
+    }
+  }
 }
+

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
@@ -23,6 +23,8 @@ import io.github.sasori_256.town_planning.entity.model.manager.RelocationManager
 import io.github.sasori_256.town_planning.entity.model.manager.SoulManager;
 import io.github.sasori_256.town_planning.entity.model.manager.TimeManager;
 import io.github.sasori_256.town_planning.entity.resident.Resident;
+import io.github.sasori_256.town_planning.entity.resident.ResidentState;
+import io.github.sasori_256.town_planning.entity.resident.ResidentType;
 import io.github.sasori_256.town_planning.map.model.GameMap;
 import io.github.sasori_256.town_planning.map.model.TerrainType;
 
@@ -78,7 +80,6 @@ public class GameModel implements GameContext, SimulationStep {
   public GameModel(int mapWidth, int mapHeight, long seed, EventBus eventBus) {
     this.eventBus = eventBus;
     this.gameMap = new GameMap(mapWidth, mapHeight, seed, eventBus);
-    GenerateTownHall(seed); // マップ中央付近に町の中心を生成
 
     this.entityManager = new EntityManager(eventBus, stateLock);
     this.soulManager = new SoulManager(eventBus, stateLock, entityManager, INITIAL_SOUL);
@@ -91,6 +92,7 @@ public class GameModel implements GameContext, SimulationStep {
     this.gameLoop = null;
 
     GameConfig.preload();
+    GenerateTownHall(seed); // マップ中央付近に町の中心を生成
   }
 
   /**
@@ -421,7 +423,7 @@ public class GameModel implements GameContext, SimulationStep {
       }
     });
   }
-  
+
   /**
    * マップ中央付近に町の中心を生成する。
    * 
@@ -436,7 +438,7 @@ public class GameModel implements GameContext, SimulationStep {
     final int MAX_LOOP_COUNT = 10;
     // マップの中央を基準に正規分布に従ってオフセットを決定
     // 配置しようとした位置が海だった場合はseedを変えて再試行する
-    int offsetX, offsetY, townHallX = width/2, townHallY = height/2, loopCount = 0;
+    int offsetX, offsetY, townHallX = width / 2, townHallY = height / 2, loopCount = 0;
     boolean foundProperPos = false; // 陸地が見つかったかどうか
     while (loopCount < MAX_LOOP_COUNT) {
       offsetX = (int) Math.round(rand.nextGaussian() * width / 10);
@@ -457,7 +459,8 @@ public class GameModel implements GameContext, SimulationStep {
           townHallX = x;
           townHallY = y;
           foundProperPos = true;
-          System.out.println("Warning: マップ中央付近に適切な陸地が見つかりませんでした。最初に見つかった陸地に町の中心を配置します。");
+          System.out
+              .println("Warning: マップ中央付近に適切な陸地が見つかりませんでした。最初に見つかった陸地に町の中心を配置します。");
         }
       }
     }
@@ -468,20 +471,17 @@ public class GameModel implements GameContext, SimulationStep {
       townHallY = centerY;
     }
 
-    // TODO: 町の中心として一旦青い屋根の家を使用　正しい建物タイプに変更する必要あり
-    // TODO: 住民の初期スポーンもここで行うはずなのだが、(続)
-    // Exception in thread "main" java.lang.NullPointerException: Cannot invoke "io.github.sasori_256.town_planning.entity.model.manager.EntityManager.spawnEntity(io.github.sasori_256.town_planning.entity.model.BaseGameEntity, io.github.sasori_256.town_planning.entity.model.GameContext)" because "this.entityManager" is null
-    // エラーが発生するためコメントアウト中
+    // TODO: 町の中心として一旦青い屋根の家を使用 正しい建物タイプに変更する必要あり
+    // TODO: 町の中心に相当する建物タイプに置き換える。
     Point2D.Double townHallPos = new Point2D.Double(townHallX, townHallY);
     Building townHall = new Building(townHallPos, BuildingType.BLUE_ROOFED_HOUSE);
     if (gameMap.placeBuilding(townHallPos, townHall)) {
       townHall.setCurrentPopulation(2);
-      // spawnEntity(townHall);
-      // spawnEntity(new Resident(new Point2D.Double(townHallPos.y, townHallPos.x),
-          // ResidentType.CITIZEN, ResidentState.AT_HOME, townHallPos));
-      // spawnEntity(new Resident(new Point2D.Double(townHallPos.y, townHallPos.x),
-          // ResidentType.CITIZEN, ResidentState.AT_HOME, townHallPos));
+      spawnEntity(townHall);
+      spawnEntity(new Resident(new Point2D.Double(townHallPos.y, townHallPos.x), ResidentType.CITIZEN,
+          ResidentState.AT_HOME, townHallPos));
+      spawnEntity(new Resident(new Point2D.Double(townHallPos.y, townHallPos.x),
+          ResidentType.CITIZEN, ResidentState.AT_HOME, townHallPos));
     }
   }
 }
-

--- a/app/src/main/java/io/github/sasori_256/town_planning/map/model/GameMap.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/map/model/GameMap.java
@@ -1,6 +1,7 @@
 package io.github.sasori_256.town_planning.map.model;
 
 import java.awt.geom.Point2D;
+
 import io.github.sasori_256.town_planning.common.event.EventBus;
 import io.github.sasori_256.town_planning.common.event.events.MapUpdatedEvent;
 import io.github.sasori_256.town_planning.entity.building.Building;
@@ -20,15 +21,15 @@ public class GameMap implements MapContext {
    *
    * @param width    横幅(セル数)
    * @param height   縦幅(セル数)
-   * @param eventBus イベントバス
    * @param seed     シード値
+   * @param eventBus イベントバス
    */
   public GameMap(int width, int height, long seed, EventBus eventBus) {
     this.width = width;
     this.height = height;
     this.eventBus = eventBus;
     this.cells = new MapCell[height][width];
-    GenerateMapTerrain(seed);
+    GenerateMapTerrain(seed); // マップの地形を生成
   }
 
   /**


### PR DESCRIPTION
マップ生成時に街の中心として青い屋根の家をマップ中央付近に配置するようにしました。

GameModelに変更が加わっています。

街の中心(TownHall)生成時に住民をスポーンさせる処理(spawnEntity)を実行しなきゃいけないと思うのですが、なんかエラーが出るので一旦コメントアウトしています。直し方が分かる場合は修正しておいてくれると助かります。