### PR TITLE
Fix/181 distribute gamewindow responsibility

### DIFF
--- a/app/src/main/java/io/github/sasori_256/town_planning/App.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/App.java
@@ -1,16 +1,10 @@
 package io.github.sasori_256.town_planning;
 
-import java.util.concurrent.locks.ReadWriteLock;
-
 import javax.swing.SwingUtilities;
 
-import io.github.sasori_256.town_planning.common.event.EventBus;
 import io.github.sasori_256.town_planning.common.ui.ImageManager;
+import io.github.sasori_256.town_planning.common.ui.main.GameFlowController;
 import io.github.sasori_256.town_planning.common.ui.main.GameWindow;
-import io.github.sasori_256.town_planning.entity.Camera;
-import io.github.sasori_256.town_planning.entity.model.GameModel;
-import io.github.sasori_256.town_planning.map.controller.GameMapController;
-import io.github.sasori_256.town_planning.map.model.GameMap;
 
 /**
  * アプリケーションのエントリーポイント。
@@ -28,20 +22,12 @@ public class App {
     final int MAP_HEIGHT = 100;
     final long SEED = 0L;
 
-    ImageManager imageManager = new ImageManager();
-
-    EventBus eventBus = new EventBus();
-    GameModel gameModel = new GameModel(MAP_WIDTH, MAP_HEIGHT, SEED, eventBus);
-    GameMap gameMap = gameModel.getGameMap();
-
-    Camera camera = new Camera(1, WIDTH, HEIGHT, MAP_WIDTH, MAP_HEIGHT, eventBus);
-    ReadWriteLock stateLock = gameModel.getStateLock();
-    GameMapController gameMapController = new GameMapController(camera, stateLock);
     SwingUtilities.invokeLater(() -> {
-      GameWindow gameWindow = new GameWindow(
-          // TODO: gameMapを引数に渡すのが冗長なのでgameModelからgetするように変更する
-          gameModel, camera, WIDTH, HEIGHT, eventBus, gameMapController, stateLock, imageManager);
-      gameModel.startGameLoop(gameWindow::repaint);
+      ImageManager imageManager = new ImageManager();
+      GameWindow gameWindow = new GameWindow(WIDTH, HEIGHT);
+      GameFlowController controller = new GameFlowController(
+          gameWindow, imageManager, WIDTH, HEIGHT, MAP_WIDTH, MAP_HEIGHT, SEED);
+      controller.initialize();
     });
   }
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/App.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/App.java
@@ -3,7 +3,6 @@ package io.github.sasori_256.town_planning;
 import javax.swing.SwingUtilities;
 
 import io.github.sasori_256.town_planning.common.core.FontManager;
-import io.github.sasori_256.town_planning.common.event.EventBus;
 import io.github.sasori_256.town_planning.common.ui.ImageManager;
 import io.github.sasori_256.town_planning.common.ui.main.GameFlowController;
 import io.github.sasori_256.town_planning.common.ui.main.GameWindow;
@@ -26,16 +25,7 @@ public class App {
 
     new FontManager();
     ImageManager imageManager = new ImageManager();
-
-    EventBus eventBus = new EventBus();
-    GameModel gameModel = new GameModel(MAP_WIDTH, MAP_HEIGHT, SEED, eventBus);
-    GameMap gameMap = gameModel.getGameMap();
-
-    Camera camera = new Camera(1, WIDTH, HEIGHT, MAP_WIDTH, MAP_HEIGHT, eventBus);
-    ReadWriteLock stateLock = gameModel.getStateLock();
-    GameMapController gameMapController = new GameMapController(camera, stateLock);
     SwingUtilities.invokeLater(() -> {
-      ImageManager imageManager = new ImageManager();
       GameWindow gameWindow = new GameWindow(WIDTH, HEIGHT);
       GameFlowController controller = new GameFlowController(
           gameWindow, imageManager, WIDTH, HEIGHT, MAP_WIDTH, MAP_HEIGHT, SEED);

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/core/GameConfig.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/core/GameConfig.java
@@ -20,8 +20,28 @@ public final class GameConfig {
   private GameConfig() {
   }
 
+  public static double getGameLoopTimeStepSeconds() {
+    return getPositiveDouble("game.loop.timeStepSeconds", 1.0 / 30.0);
+  }
+
+  public static double getAnimationStepSeconds() {
+    return getPositiveDouble("game.animation.stepSeconds", 1.0 / 30.0);
+  }
+
+  public static double getTimeDayLengthSeconds() {
+    return getPositiveDouble("time.dayLengthSeconds", 10.0);
+  }
+
+  public static double getTimeScale() {
+    return getNonNegativeDouble("time.scale", 1.0);
+  }
+
+  public static int getSoulInitialAmount() {
+    return getNonNegativeInt("soul.initialAmount", 100);
+  }
+
   public static double getCorpseHarvestDelaySeconds() {
-    return getDouble("corpse.harvestDelaySeconds", 2.0);
+    return getPositiveDouble("corpse.harvestDelaySeconds", 2.0);
   }
 
   public static int getCorpseSoulBase() {
@@ -48,6 +68,18 @@ public final class GameConfig {
     return getPositiveDouble("resident.moveSpeedTilesPerSecond", 2.0);
   }
 
+  public static int getResidentGrowthMinHomePopulation() {
+    return getNonNegativeInt("resident.growth.minHomePopulation", 2);
+  }
+
+  public static double getResidentGrowthSpawnIntervalSeconds() {
+    return getPositiveDouble("resident.growth.spawnIntervalSeconds", 15.0);
+  }
+
+  public static double getResidentGrowthSpawnChance() {
+    return getNonNegativeDouble("resident.growth.spawnChance", 0.5);
+  }
+
   public static double getResidentPanicSpeedTilesPerSecond() {
     return getPositiveDouble("resident.panic.speedTilesPerSecond", 3.0);
   }
@@ -72,11 +104,80 @@ public final class GameConfig {
     return getNonNegativeDouble("resident.panic.radiusTiles", 3.0);
   }
 
+  public static double getResidentDeathAnimationDurationSeconds() {
+    return getNonNegativeDouble("resident.death.animationDurationSeconds", 0.4);
+  }
+
+  public static int getResidentRelocationMinResidentsPerHouse() {
+    return getPositiveInt("resident.relocation.minResidentsPerHouse", 2);
+  }
+
+  public static double getPathfindingArrivalEpsilonTiles() {
+    return getNonNegativeDouble("pathfinding.arrivalEpsilonTiles", 1e-3);
+  }
+
+  public static double getPathfindingSearchCooldownSeconds() {
+    return getNonNegativeDouble("pathfinding.searchCooldownSeconds", 0.5);
+  }
+
+  public static int getPathfindingMaxRandomTries() {
+    return getPositiveInt("pathfinding.maxRandomTries", 20);
+  }
+
+  public static long getPathfindingCostInf() {
+    return getNonNegativeLong("pathfinding.costInf", 1_000_000L);
+  }
+
+  public static double getCameraZoomStep() {
+    return getPositiveDouble("camera.zoom.step", 0.25);
+  }
+
+  public static int getCameraZoomMinLevel() {
+    return getPositiveInt("camera.zoom.minLevel", 1);
+  }
+
+  public static int getCameraZoomMaxLevel() {
+    return getPositiveInt("camera.zoom.maxLevel", 12);
+  }
+
+  public static int getToastDisplayMillis() {
+    return getPositiveInt("ui.toast.displayMillis", 3000);
+  }
+
+  public static int getToastMaxVisible() {
+    return getPositiveInt("ui.toast.maxVisible", 3);
+  }
+
+  public static int getToastMarginPixels() {
+    return getNonNegativeInt("ui.toast.marginPixels", 12);
+  }
+
+  public static int getToastSpacingPixels() {
+    return getNonNegativeInt("ui.toast.spacingPixels", 8);
+  }
+
   public static double getDisasterPanicRadiusOffsetTiles() {
     return getNonNegativeDouble("disaster.panicRadiusOffsetTiles", 3.0);
   }
 
+  public static double getDisasterMeteorImpactSeconds() {
+    return getPositiveDouble("disaster.meteor.impactSeconds", 2.0);
+  }
+
+  public static double getDisasterMeteorEffectDurationSeconds() {
+    return getNonNegativeDouble("disaster.meteor.effectDurationSeconds", 1.0);
+  }
+
+  public static int getDisasterMeteorAnimationFps() {
+    return getPositiveInt("disaster.meteor.animationFps", 6);
+  }
+
   public static void preload() {
+    getGameLoopTimeStepSeconds();
+    getAnimationStepSeconds();
+    getTimeDayLengthSeconds();
+    getTimeScale();
+    getSoulInitialAmount();
     getCorpseHarvestDelaySeconds();
     getCorpseSoulBase();
     getCorpseSoulFaithDivisor();
@@ -84,13 +185,32 @@ public final class GameConfig {
     getResidentHomeWaitMinSeconds();
     getResidentHomeWaitMaxSeconds();
     getResidentMoveSpeedTilesPerSecond();
+    getResidentGrowthMinHomePopulation();
+    getResidentGrowthSpawnIntervalSeconds();
+    getResidentGrowthSpawnChance();
     getResidentPanicSpeedTilesPerSecond();
     getResidentPanicRetargetMinSeconds();
     getResidentPanicRetargetMaxSeconds();
     getResidentPanicDurationMinSeconds();
     getResidentPanicDurationMaxSeconds();
     getResidentPanicRadiusTiles();
+    getResidentDeathAnimationDurationSeconds();
+    getResidentRelocationMinResidentsPerHouse();
+    getPathfindingArrivalEpsilonTiles();
+    getPathfindingSearchCooldownSeconds();
+    getPathfindingMaxRandomTries();
+    getPathfindingCostInf();
+    getCameraZoomStep();
+    getCameraZoomMinLevel();
+    getCameraZoomMaxLevel();
+    getToastDisplayMillis();
+    getToastMaxVisible();
+    getToastMarginPixels();
+    getToastSpacingPixels();
     getDisasterPanicRadiusOffsetTiles();
+    getDisasterMeteorImpactSeconds();
+    getDisasterMeteorEffectDurationSeconds();
+    getDisasterMeteorAnimationFps();
   }
 
   public static void reportErrors() {
@@ -136,6 +256,19 @@ public final class GameConfig {
     }
   }
 
+  private static long getLong(String key, long defaultValue) {
+    String raw = PROPERTIES.getProperty(key);
+    if (raw == null) {
+      return defaultValue;
+    }
+    try {
+      return Long.parseLong(raw.trim());
+    } catch (NumberFormatException e) {
+      recordError("CONFIG_PARSE_FAILED", "Invalid long for " + key + ": " + raw);
+      return defaultValue;
+    }
+  }
+
   private static int getNonNegativeInt(String key, int defaultValue) {
     int value = getInt(key, defaultValue);
     return value < 0 ? defaultValue : value;
@@ -154,6 +287,11 @@ public final class GameConfig {
   private static double getPositiveDouble(String key, double defaultValue) {
     double value = getDouble(key, defaultValue);
     return value <= 0.0 ? defaultValue : value;
+  }
+
+  private static long getNonNegativeLong(String key, long defaultValue) {
+    long value = getLong(key, defaultValue);
+    return value < 0L ? defaultValue : value;
   }
 
   private static int getInt(String key, int defaultValue) {

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/core/GameConfig.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/core/GameConfig.java
@@ -32,10 +32,65 @@ public final class GameConfig {
     return getPositiveInt("corpse.soulFaithDivisor", 5);
   }
 
+  public static double getResidentWorkDurationSeconds() {
+    return getPositiveDouble("resident.workDurationSeconds", 5.0);
+  }
+
+  public static double getResidentHomeWaitMinSeconds() {
+    return getNonNegativeDouble("resident.homeWaitMinSeconds", 8.0);
+  }
+
+  public static double getResidentHomeWaitMaxSeconds() {
+    return getNonNegativeDouble("resident.homeWaitMaxSeconds", 20.0);
+  }
+
+  public static double getResidentMoveSpeedTilesPerSecond() {
+    return getPositiveDouble("resident.moveSpeedTilesPerSecond", 2.0);
+  }
+
+  public static double getResidentPanicSpeedTilesPerSecond() {
+    return getPositiveDouble("resident.panic.speedTilesPerSecond", 3.0);
+  }
+
+  public static double getResidentPanicRetargetMinSeconds() {
+    return getNonNegativeDouble("resident.panic.retargetMinSeconds", 0.2);
+  }
+
+  public static double getResidentPanicRetargetMaxSeconds() {
+    return getNonNegativeDouble("resident.panic.retargetMaxSeconds", 0.6);
+  }
+
+  public static double getResidentPanicDurationMinSeconds() {
+    return getNonNegativeDouble("resident.panic.durationMinSeconds", 4.0);
+  }
+
+  public static double getResidentPanicDurationMaxSeconds() {
+    return getNonNegativeDouble("resident.panic.durationMaxSeconds", 8.0);
+  }
+
+  public static double getResidentPanicRadiusTiles() {
+    return getNonNegativeDouble("resident.panic.radiusTiles", 3.0);
+  }
+
+  public static double getDisasterPanicRadiusOffsetTiles() {
+    return getNonNegativeDouble("disaster.panicRadiusOffsetTiles", 3.0);
+  }
+
   public static void preload() {
     getCorpseHarvestDelaySeconds();
     getCorpseSoulBase();
     getCorpseSoulFaithDivisor();
+    getResidentWorkDurationSeconds();
+    getResidentHomeWaitMinSeconds();
+    getResidentHomeWaitMaxSeconds();
+    getResidentMoveSpeedTilesPerSecond();
+    getResidentPanicSpeedTilesPerSecond();
+    getResidentPanicRetargetMinSeconds();
+    getResidentPanicRetargetMaxSeconds();
+    getResidentPanicDurationMinSeconds();
+    getResidentPanicDurationMaxSeconds();
+    getResidentPanicRadiusTiles();
+    getDisasterPanicRadiusOffsetTiles();
   }
 
   public static void reportErrors() {
@@ -89,6 +144,16 @@ public final class GameConfig {
   private static int getPositiveInt(String key, int defaultValue) {
     int value = getInt(key, defaultValue);
     return value <= 0 ? defaultValue : value;
+  }
+
+  private static double getNonNegativeDouble(String key, double defaultValue) {
+    double value = getDouble(key, defaultValue);
+    return value < 0.0 ? defaultValue : value;
+  }
+
+  private static double getPositiveDouble(String key, double defaultValue) {
+    double value = getDouble(key, defaultValue);
+    return value <= 0.0 ? defaultValue : value;
   }
 
   private static int getInt(String key, int defaultValue) {

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/core/GameLoop.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/core/GameLoop.java
@@ -23,8 +23,7 @@ public class GameLoop implements Runnable {
   private Thread thread = null;
 
   // 30 FPS target
-  // TODO: マジックナンバーを定数化して外部から変更できるようにする
-  private static final double TIME_STEP = 1.0 / 30.0;
+  private static final double TIME_STEP = GameConfig.getGameLoopTimeStepSeconds();
   private static final long TIME_STEP_NANO = (long) (TIME_STEP * 1_000_000_000);
 
   /**

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/CustomButton.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/CustomButton.java
@@ -123,12 +123,27 @@ public class CustomButton extends JButton {
    * @param height 高さ
    */
   public final void setCustomBounds(int x, int y, int width, int height) {
-    super.setBounds(x, y, width, height);
+    setBounds(x, y, width, height);
     this.setPreferredSize(new Dimension(width, height));
     this.originalWidth = width;
     this.originalHeight = height;
     this.centerX = x + width / 2;
     this.centerY = y + height / 2;
+  }
+
+  /**
+   * レイアウト更新時に位置とサイズを更新する。
+   *
+   * @param x      左上X
+   * @param y      左上Y
+   * @param width  幅
+   * @param height 高さ
+   */
+  public void updateLayout(int x, int y, int width, int height) {
+    setCustomBounds(x, y, width, height);
+    if (originalImage != null) {
+      setImage(originalImage, width, height);
+    }
   }
 
   private void setBoundsCentered(int width, int height) {
@@ -137,9 +152,16 @@ public class CustomButton extends JButton {
     } else {
       int x = centerX - width / 2;
       int y = centerY - height / 2;
-      super.setBounds(x, y, width, height);
+      setBounds(x, y, width, height);
       setPreferredSize(new Dimension(width, height));
     }
+  }
+
+  @Override
+  public void setBounds(int x, int y, int width, int height) {
+    super.setBounds(x, y, width, height);
+    this.centerX = x + width / 2;
+    this.centerY = y + height / 2;
   }
 
   /**

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/PaintGameObject.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/PaintGameObject.java
@@ -115,7 +115,7 @@ public class PaintGameObject {
    * @param panel        描画対象のパネル
    */
   public void paintResident(Graphics g, Resident resident, Camera camera, ImageManager imageManager,
-      JPanel panel) {
+      AnimationManager animationManager, JPanel panel) {
     if (resident == null || resident.getType() == null) {
       return;
     }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/ToastManager.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/ToastManager.java
@@ -1,5 +1,6 @@
 package io.github.sasori_256.town_planning.common.ui;
 
+import io.github.sasori_256.town_planning.common.core.GameConfig;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.event.ComponentAdapter;
@@ -12,10 +13,10 @@ import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 
 public class ToastManager {
-  private static final int DISPLAY_MILLIS = 3000;
-  private static final int MAX_VISIBLE = 3;
-  private static final int MARGIN = 12;
-  private static final int SPACING = 8;
+  private static final int DISPLAY_MILLIS = GameConfig.getToastDisplayMillis();
+  private static final int MAX_VISIBLE = GameConfig.getToastMaxVisible();
+  private static final int MARGIN = GameConfig.getToastMarginPixels();
+  private static final int SPACING = GameConfig.getToastSpacingPixels();
 
   private final JLayeredPane layeredPane;
   private final JComponent anchor;

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/view/PaintObjectSelectUI.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/gameObjectSelect/view/PaintObjectSelectUI.java
@@ -53,53 +53,53 @@ public class PaintObjectSelectUI {
 
   private void createButtonIfNotExists(String buttonText, int xPos, int yPos, int width, int height,
       ActionListener actionListener, MenuNode objectNode, int level) {
-    boolean exists = false;
+    CustomButton existingButton = null;
     for (CustomButton button : createdButtons.get(level)) {
       if (button.getTextContent().equals(buttonText)) {
-        exists = true;
+        existingButton = button;
         break;
       }
     }
-    if (!exists) { // 同じ名前のボタンが存在しない場合は追加する
-      String prefix = "";
-      switch (level) {
-        case 0:
-          prefix = "modeIcon_";
-          break;
-        case 1:
-          prefix = "categoryIcon_";
-          break;
-        case 2:
-          prefix = "objectIcon_";
-          break;
-      }
-      String imageName = prefix + buttonText.toLowerCase();
-      ImageStorage imageStorage = imageManager.getImageStorage(imageName);
-      CustomButton button;
-      if (imageStorage == null || imageStorage.getName() == null || imageStorage.getName().equals("error")) {
-        // System.err.println("Warning: Image not found: " + imageName);
-        button = new CustomButton(buttonText, xPos, yPos, width, height); // 画像が見つからない場合はテキストだけのボタンを使用
-      } else {
-        button = new CustomButton(buttonText, imageStorage, xPos, yPos, width, height); // 画像が見つかった場合は画像だけのボタンを使用
-        // button.setImage(imageStorage.getImage(), width, height);
-      }
-      // ボタンの画像を指定
-      button.addActionListener(actionListener);
-      if (objectNode != null) {
-        button.addActionListener(objectNode);
-      }
-      createdButtons.get(level).add(button);
-      panel.add(button);
+    if (existingButton != null) {
+      existingButton.updateLayout(xPos, yPos, width, height);
+      return;
     }
+    // 同じ名前のボタンが存在しない場合は追加する
+    String prefix = "";
+    switch (level) {
+      case 0:
+        prefix = "modeIcon_";
+        break;
+      case 1:
+        prefix = "categoryIcon_";
+        break;
+      case 2:
+        prefix = "objectIcon_";
+        break;
+    }
+    String imageName = prefix + buttonText.toLowerCase();
+    ImageStorage imageStorage = imageManager.getImageStorage(imageName);
+    CustomButton button;
+    if (imageStorage == null || imageStorage.getName() == null || imageStorage.getName().equals("error")) {
+      // System.err.println("Warning: Image not found: " + imageName);
+      button = new CustomButton(buttonText, xPos, yPos, width, height); // 画像が見つからない場合はテキストだけのボタンを使用
+    } else {
+      button = new CustomButton(buttonText, imageStorage, xPos, yPos, width, height); // 画像が見つかった場合は画像だけのボタンを使用
+      // button.setImage(imageStorage.getImage(), width, height);
+    }
+    // ボタンの画像を指定
+    button.addActionListener(actionListener);
+    if (objectNode != null) {
+      button.addActionListener(objectNode);
+    }
+    createdButtons.get(level).add(button);
+    panel.add(button);
   }
 
   /**
    * 全てのlevelのボタンを再配置・再描画する
    */
   public void repaintUI() {
-    clearButtonLevel(0);
-    clearButtonLevel(1);
-    clearButtonLevel(2);
     paint();
   }
 
@@ -252,9 +252,9 @@ public class PaintObjectSelectUI {
         createButtonIfNotExists(buttonText, xPos, yPos, width, height, listener, categoryNode, 1);
       }
     } else {
-      if (categoryRoot == null) {
+      if (categoryRoot == null && !selectedModeName.isEmpty()) {
         System.err.println("Selected mode root is null for mode: " + selectedModeName);
-      } else {
+      } else if (categoryRoot != null && !selectedModeName.isEmpty()) {
         System.out.println("No children in category root for mode: " + selectedModeName);
       }
     }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameFlowController.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameFlowController.java
@@ -19,6 +19,9 @@ import io.github.sasori_256.town_planning.common.ui.ToastManager;
 import io.github.sasori_256.town_planning.common.ui.main.scene.EndPanel;
 import io.github.sasori_256.town_planning.common.ui.main.scene.TitlePanel;
 
+/**
+ * タイトル・ゲーム・結果画面の遷移とセッション管理を統括する。
+ */
 public class GameFlowController implements GameFlowNavigator {
   private final GameWindow window;
   private final ImageManager imageManager;
@@ -37,6 +40,17 @@ public class GameFlowController implements GameFlowNavigator {
   private Timer gameOverTimer;
   private final AtomicBoolean gameOverHandled = new AtomicBoolean(false);
 
+  /**
+   * ゲーム遷移のコントローラを生成する。
+   *
+   * @param window       表示用ウィンドウ
+   * @param imageManager 画像管理
+   * @param windowWidth  ウィンドウ幅
+   * @param windowHeight ウィンドウ高さ
+   * @param mapWidth     マップ幅
+   * @param mapHeight    マップ高さ
+   * @param seed         マップ生成シード
+   */
   public GameFlowController(
       GameWindow window,
       ImageManager imageManager,
@@ -61,6 +75,9 @@ public class GameFlowController implements GameFlowNavigator {
     });
   }
 
+  /**
+   * タイトル/結果画面を初期化し、初期シーンへ遷移する。
+   */
   public void initialize() {
     this.titlePanel = new TitlePanel(this, imageManager);
     this.endPanel = new EndPanel(this);
@@ -69,6 +86,7 @@ public class GameFlowController implements GameFlowNavigator {
     window.showScene(SceneId.TITLE);
   }
 
+  /** {@inheritDoc} */
   @Override
   public void startNewGame() {
     clearGameOverTimer();
@@ -83,6 +101,7 @@ public class GameFlowController implements GameFlowNavigator {
     currentSession.start(window::repaint);
   }
 
+  /** {@inheritDoc} */
   @Override
   public void goToTitle() {
     clearGameOverTimer();
@@ -90,6 +109,9 @@ public class GameFlowController implements GameFlowNavigator {
     window.showScene(SceneId.TITLE);
   }
 
+  /**
+   * セッション固有のイベント購読を登録する。
+   */
   private void attachSessionSubscriptions(GameSession session) {
     EventBus eventBus = session.getEventBus();
     configSub = eventBus.subscribe(ConfigLoadFailedEvent.class,
@@ -100,6 +122,9 @@ public class GameFlowController implements GameFlowNavigator {
     GameConfig.reportErrors();
   }
 
+  /**
+   * ゲームオーバー処理をまとめて実行する。
+   */
   private void handleGameOver() {
     if (currentSession == null) {
       return;
@@ -115,6 +140,9 @@ public class GameFlowController implements GameFlowNavigator {
     scheduleGameOverTransition();
   }
 
+  /**
+   * 結果画面へ遷移するタイマーを設定する。
+   */
   private void scheduleGameOverTransition() {
     clearGameOverTimer();
     gameOverTimer = new Timer(3000, event -> {
@@ -125,6 +153,9 @@ public class GameFlowController implements GameFlowNavigator {
     gameOverTimer.start();
   }
 
+  /**
+   * ゲームオーバー遷移タイマーを解除する。
+   */
   private void clearGameOverTimer() {
     if (gameOverTimer != null) {
       gameOverTimer.stop();
@@ -132,6 +163,9 @@ public class GameFlowController implements GameFlowNavigator {
     }
   }
 
+  /**
+   * セッションと関連する購読を破棄する。
+   */
   private void disposeSession() {
     if (currentSession != null) {
       currentSession.dispose();
@@ -145,6 +179,9 @@ public class GameFlowController implements GameFlowNavigator {
     gameOverSub = null;
   }
 
+  /**
+   * 現在のウィンドウサイズへカメラを合わせる。
+   */
   private void updateCameraToWindow() {
     if (currentSession == null) {
       return;
@@ -156,6 +193,9 @@ public class GameFlowController implements GameFlowNavigator {
     currentSession.updateCameraScreenSize(size.width, size.height);
   }
 
+  /**
+   * 購読解除を安全に行う。
+   */
   private void unsubscribe(Subscription subscription) {
     if (subscription != null) {
       subscription.unsubscribe();

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameFlowController.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameFlowController.java
@@ -1,0 +1,207 @@
+package io.github.sasori_256.town_planning.common.ui.main;
+
+import java.awt.Dimension;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.Timer;
+
+import io.github.sasori_256.town_planning.common.core.GameConfig;
+import io.github.sasori_256.town_planning.common.event.EventBus;
+import io.github.sasori_256.town_planning.common.event.Subscription;
+import io.github.sasori_256.town_planning.common.event.events.ConfigLoadFailedEvent;
+import io.github.sasori_256.town_planning.common.event.events.EntitySpawnFailedEvent;
+import io.github.sasori_256.town_planning.common.event.events.EntitySpawnFailureReason;
+import io.github.sasori_256.town_planning.common.event.events.EntitySpawnKind;
+import io.github.sasori_256.town_planning.common.event.events.GameOverEvent;
+import io.github.sasori_256.town_planning.common.ui.ImageManager;
+import io.github.sasori_256.town_planning.common.ui.ToastManager;
+import io.github.sasori_256.town_planning.common.ui.main.scene.EndPanel;
+import io.github.sasori_256.town_planning.common.ui.main.scene.TitlePanel;
+
+public class GameFlowController implements GameFlowNavigator {
+  private final GameWindow window;
+  private final ImageManager imageManager;
+  private final int windowWidth;
+  private final int windowHeight;
+  private final int mapWidth;
+  private final int mapHeight;
+  private final long seed;
+
+  private TitlePanel titlePanel;
+  private EndPanel endPanel;
+  private GameSession currentSession;
+  private Subscription configSub;
+  private Subscription spawnSub;
+  private Subscription gameOverSub;
+  private Timer gameOverTimer;
+  private final AtomicBoolean gameOverHandled = new AtomicBoolean(false);
+
+  public GameFlowController(
+      GameWindow window,
+      ImageManager imageManager,
+      int windowWidth,
+      int windowHeight,
+      int mapWidth,
+      int mapHeight,
+      long seed) {
+    this.window = window;
+    this.imageManager = imageManager;
+    this.windowWidth = windowWidth;
+    this.windowHeight = windowHeight;
+    this.mapWidth = mapWidth;
+    this.mapHeight = mapHeight;
+    this.seed = seed;
+
+    this.window.addComponentListener(new ComponentAdapter() {
+      @Override
+      public void componentResized(ComponentEvent e) {
+        updateCameraToWindow();
+      }
+    });
+  }
+
+  public void initialize() {
+    this.titlePanel = new TitlePanel(this, imageManager);
+    this.endPanel = new EndPanel(this);
+    window.setScene(SceneId.TITLE, titlePanel);
+    window.setScene(SceneId.END, endPanel);
+    window.showScene(SceneId.TITLE);
+  }
+
+  @Override
+  public void startNewGame() {
+    clearGameOverTimer();
+    disposeSession();
+    gameOverHandled.set(false);
+
+    currentSession = new GameSession(windowWidth, windowHeight, mapWidth, mapHeight, seed, imageManager, this);
+    window.setScene(SceneId.GAME, currentSession.getView());
+    window.showScene(SceneId.GAME);
+    attachSessionSubscriptions(currentSession);
+    updateCameraToWindow();
+    currentSession.start(window::repaint);
+  }
+
+  @Override
+  public void goToTitle() {
+    clearGameOverTimer();
+    disposeSession();
+    window.showScene(SceneId.TITLE);
+  }
+
+  private void attachSessionSubscriptions(GameSession session) {
+    EventBus eventBus = session.getEventBus();
+    configSub = eventBus.subscribe(ConfigLoadFailedEvent.class,
+        event -> window.showToast(buildConfigMessage(event), ToastManager.ToastType.ERROR));
+    spawnSub = eventBus.subscribe(EntitySpawnFailedEvent.class,
+        event -> window.showToast(buildSpawnFailureMessage(event), ToastManager.ToastType.WARNING));
+    gameOverSub = eventBus.subscribe(GameOverEvent.class, event -> handleGameOver());
+    GameConfig.reportErrors(eventBus);
+  }
+
+  private void handleGameOver() {
+    if (currentSession == null) {
+      return;
+    }
+    if (!gameOverHandled.compareAndSet(false, true)) {
+      return;
+    }
+    window.showToast("住民がいなくなりました。", ToastManager.ToastType.INFO);
+    currentSession.pause();
+
+    GameResult result = currentSession.snapshot();
+    endPanel.setResult(result);
+    scheduleGameOverTransition();
+  }
+
+  private void scheduleGameOverTransition() {
+    clearGameOverTimer();
+    gameOverTimer = new Timer(3000, event -> {
+      disposeSession();
+      window.showScene(SceneId.END);
+    });
+    gameOverTimer.setRepeats(false);
+    gameOverTimer.start();
+  }
+
+  private void clearGameOverTimer() {
+    if (gameOverTimer != null) {
+      gameOverTimer.stop();
+      gameOverTimer = null;
+    }
+  }
+
+  private void disposeSession() {
+    if (currentSession != null) {
+      currentSession.dispose();
+      currentSession = null;
+    }
+    unsubscribe(configSub);
+    unsubscribe(spawnSub);
+    unsubscribe(gameOverSub);
+    configSub = null;
+    spawnSub = null;
+    gameOverSub = null;
+  }
+
+  private void updateCameraToWindow() {
+    if (currentSession == null) {
+      return;
+    }
+    Dimension size = window.getSceneSize();
+    if (size.width <= 0 || size.height <= 0) {
+      return;
+    }
+    currentSession.updateCameraScreenSize(size.width, size.height);
+  }
+
+  private void unsubscribe(Subscription subscription) {
+    if (subscription != null) {
+      subscription.unsubscribe();
+    }
+  }
+
+  private static String buildConfigMessage(ConfigLoadFailedEvent event) {
+    String code = event.code();
+    if ("CONFIG_NOT_FOUND".equals(code)) {
+      return "設定ファイルが見つかりません (game.properties)";
+    }
+    if ("CONFIG_LOAD_FAILED".equals(code)) {
+      return "設定ファイルの読み込みに失敗しました";
+    }
+    if ("CONFIG_PARSE_FAILED".equals(code)) {
+      return "設定値が不正です: " + safeDetail(event.message());
+    }
+    return "設定読み込みエラー: " + safeDetail(event.message());
+  }
+
+  private static String buildSpawnFailureMessage(EntitySpawnFailedEvent event) {
+    String kindName = describeKind(event.kind());
+    EntitySpawnFailureReason reason = event.reason();
+    if (reason == EntitySpawnFailureReason.INSUFFICIENT_SOUL) {
+      return kindName + "を生成できません: 魂が足りません";
+    }
+    if (reason == EntitySpawnFailureReason.INVALID_POSITION) {
+      return kindName + "を生成できません: 設置できない場所です";
+    }
+    if (reason == EntitySpawnFailureReason.PLACEMENT_BLOCKED) {
+      return kindName + "を生成できません: 設置場所が塞がっています";
+    }
+    if (reason == EntitySpawnFailureReason.INVALID_ENTITY) {
+      return kindName + "の生成に失敗しました: 対象が不正です";
+    }
+    return kindName + "の生成に失敗しました";
+  }
+
+  private static String describeKind(EntitySpawnKind kind) {
+    if (kind == EntitySpawnKind.DISASTER) {
+      return "災害";
+    }
+    return "建物";
+  }
+
+  private static String safeDetail(String detail) {
+    return detail == null || detail.isBlank() ? "詳細不明" : detail;
+  }
+}

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameFlowNavigator.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameFlowNavigator.java
@@ -1,7 +1,16 @@
 package io.github.sasori_256.town_planning.common.ui.main;
 
+/**
+ * ゲームの画面遷移を要求するための窓口。
+ */
 public interface GameFlowNavigator {
+  /**
+   * 新しいゲームを開始する。
+   */
   void startNewGame();
 
+  /**
+   * タイトル画面へ遷移する。
+   */
   void goToTitle();
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameFlowNavigator.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameFlowNavigator.java
@@ -1,0 +1,7 @@
+package io.github.sasori_256.town_planning.common.ui.main;
+
+public interface GameFlowNavigator {
+  void startNewGame();
+
+  void goToTitle();
+}

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameResult.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameResult.java
@@ -1,0 +1,4 @@
+package io.github.sasori_256.town_planning.common.ui.main;
+
+public record GameResult(int day, int soul, int maxPopulation, int totalDeaths) {
+}

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameSession.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameSession.java
@@ -26,6 +26,17 @@ public class GameSession {
   private final GameMapPanel gameMapPanel;
   private Subscription mapSub;
 
+  /**
+   * ゲームセッションを生成する。
+   *
+   * @param windowWidth  ウィンドウ幅
+   * @param windowHeight ウィンドウ高さ
+   * @param mapWidth     マップ幅
+   * @param mapHeight    マップ高さ
+   * @param seed         マップ生成シード
+   * @param imageManager 画像管理
+   * @param navigator    画面遷移ナビゲータ
+   */
   public GameSession(
       int windowWidth,
       int windowHeight,
@@ -58,30 +69,50 @@ public class GameSession {
     });
   }
 
+  /**
+   * ゲーム画面のコンポーネントを返す。
+   */
   public JComponent getView() {
     return gameMapPanel;
   }
 
+  /**
+   * セッションで使用しているイベントバスを返す。
+   */
   public EventBus getEventBus() {
     return eventBus;
   }
 
+  /**
+   * ゲームループを開始する。
+   *
+   * @param renderCallback 描画更新コールバック
+   */
   public void start(Runnable renderCallback) {
     gameModel.startGameLoop(renderCallback);
   }
 
+  /**
+   * ゲームループを一時停止する。
+   */
   public void pause() {
     if (gameModel.getGameLoop() != null) {
       gameModel.getGameLoop().pause();
     }
   }
 
+  /**
+   * ゲームループを停止する。
+   */
   public void stop() {
     if (gameModel.getGameLoop() != null) {
       gameModel.getGameLoop().stop();
     }
   }
 
+  /**
+   * セッションの後始末を行う。
+   */
   public void dispose() {
     stop();
     if (mapSub != null) {
@@ -90,6 +121,9 @@ public class GameSession {
     }
   }
 
+  /**
+   * 結果画面向けのスナップショットを取得する。
+   */
   public GameResult snapshot() {
     return new GameResult(
         gameModel.getDay(),
@@ -98,6 +132,9 @@ public class GameSession {
         gameModel.getPopulationTotalDeaths());
   }
 
+  /**
+   * 画面サイズに合わせてカメラサイズを更新する。
+   */
   public void updateCameraScreenSize(int width, int height) {
     camera.setScreenSize(width, height);
   }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameSession.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameSession.java
@@ -1,0 +1,105 @@
+package io.github.sasori_256.town_planning.common.ui.main;
+
+import java.util.concurrent.locks.ReadWriteLock;
+import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
+
+import io.github.sasori_256.town_planning.common.event.EventBus;
+import io.github.sasori_256.town_planning.common.event.Subscription;
+import io.github.sasori_256.town_planning.common.event.events.MapUpdatedEvent;
+import io.github.sasori_256.town_planning.common.ui.ImageManager;
+import io.github.sasori_256.town_planning.common.ui.gameObjectSelect.controller.CategoryNode;
+import io.github.sasori_256.town_planning.common.ui.gameObjectSelect.controller.NodeMenuInitializer;
+import io.github.sasori_256.town_planning.common.ui.main.scene.GameMapPanel;
+import io.github.sasori_256.town_planning.entity.Camera;
+import io.github.sasori_256.town_planning.entity.model.GameModel;
+import io.github.sasori_256.town_planning.map.controller.GameMapController;
+import io.github.sasori_256.town_planning.map.model.GameMap;
+
+public class GameSession {
+  private final EventBus eventBus;
+  private final GameModel gameModel;
+  private final GameMap gameMap;
+  private final Camera camera;
+  private final ReadWriteLock stateLock;
+  private final GameMapController gameMapController;
+  private final GameMapPanel gameMapPanel;
+  private Subscription mapSub;
+
+  public GameSession(
+      int windowWidth,
+      int windowHeight,
+      int mapWidth,
+      int mapHeight,
+      long seed,
+      ImageManager imageManager,
+      GameFlowNavigator navigator) {
+    this.eventBus = new EventBus();
+    this.gameModel = new GameModel(mapWidth, mapHeight, seed, eventBus);
+    this.gameMap = gameModel.getGameMap();
+    this.stateLock = gameModel.getStateLock();
+    this.camera = new Camera(1, windowWidth, windowHeight, mapWidth, mapHeight, eventBus);
+    this.gameMapController = new GameMapController(camera, stateLock);
+
+    CategoryNode root = NodeMenuInitializer.setup(this.gameMapController, this.gameModel);
+    this.gameMapPanel = new GameMapPanel(this.gameMap, this.gameModel, this.camera, root, this.stateLock,
+        imageManager, navigator);
+    this.gameMapPanel.addMouseListener(this.gameMapController);
+    this.gameMapPanel.addMouseMotionListener(this.gameMapController);
+    this.gameMapPanel.addMouseWheelListener(this.gameMapController);
+    this.gameMapPanel.addKeyListener(this.gameMapController);
+    this.gameMapPanel.setFocusable(true);
+
+    this.mapSub = eventBus.subscribe(MapUpdatedEvent.class, event -> {
+      if (SwingUtilities.isEventDispatchThread()) {
+        gameMapPanel.repaint();
+      } else {
+        SwingUtilities.invokeLater(gameMapPanel::repaint);
+      }
+    });
+  }
+
+  public JComponent getView() {
+    return gameMapPanel;
+  }
+
+  public EventBus getEventBus() {
+    return eventBus;
+  }
+
+  public void start(Runnable renderCallback) {
+    gameModel.startGameLoop(renderCallback);
+  }
+
+  public void pause() {
+    if (gameModel.getGameLoop() != null) {
+      gameModel.getGameLoop().pause();
+    }
+  }
+
+  public void stop() {
+    if (gameModel.getGameLoop() != null) {
+      gameModel.getGameLoop().stop();
+    }
+  }
+
+  public void dispose() {
+    stop();
+    if (mapSub != null) {
+      mapSub.unsubscribe();
+      mapSub = null;
+    }
+  }
+
+  public GameResult snapshot() {
+    return new GameResult(
+        gameModel.getDay(),
+        gameModel.getSoul(),
+        gameModel.getPopulationMax(),
+        gameModel.getPopulationTotalDeaths());
+  }
+
+  public void updateCameraScreenSize(int width, int height) {
+    camera.setScreenSize(width, height);
+  }
+}

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameWindow.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameWindow.java
@@ -25,6 +25,12 @@ public class GameWindow extends JFrame {
   private static final int MIN_WIDTH = 640;
   private static final int MIN_HEIGHT = 480;
 
+  /**
+   * 画面遷移用のウィンドウを生成する。
+   *
+   * @param width  初期ウィンドウ幅
+   * @param height 初期ウィンドウ高さ
+   */
   public GameWindow(int width, int height) {
     setTitle("Town Planning Game");
     setSize(width, height);
@@ -45,6 +51,12 @@ public class GameWindow extends JFrame {
     setVisible(true);
   }
 
+  /**
+   * シーンを登録する。
+   *
+   * @param sceneId   シーンID
+   * @param component シーンの描画コンポーネント
+   */
   public void setScene(SceneId sceneId, JComponent component) {
     JComponent existing = scenes.put(sceneId, component);
     if (existing != null) {
@@ -55,15 +67,29 @@ public class GameWindow extends JFrame {
     this.mainPanel.repaint();
   }
 
+  /**
+   * 登録済みのシーンを表示する。
+   *
+   * @param sceneId 表示するシーンID
+   */
   public void showScene(SceneId sceneId) {
     this.cardLayout.show(this.mainPanel, sceneId.name());
     repaintCurrentSceneUI();
   }
 
+  /**
+   * トースト通知を表示する。
+   *
+   * @param message 表示文
+   * @param type    通知タイプ
+   */
   public void showToast(String message, ToastManager.ToastType type) {
     toastManager.show(message, type);
   }
 
+  /**
+   * 現在のシーン領域サイズを返す。
+   */
   public Dimension getSceneSize() {
     return this.mainPanel.getSize();
   }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameWindow.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/GameWindow.java
@@ -3,156 +3,69 @@ package io.github.sasori_256.town_planning.common.ui.main;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.event.ComponentAdapter;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReadWriteLock;
+import java.awt.event.ComponentEvent;
+import java.util.EnumMap;
+import java.util.Map;
+import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
-import javax.swing.Timer;
 
-import io.github.sasori_256.town_planning.common.core.GameConfig;
-import io.github.sasori_256.town_planning.common.event.EventBus;
-import io.github.sasori_256.town_planning.common.event.Subscription;
-import io.github.sasori_256.town_planning.common.event.events.ConfigLoadFailedEvent;
-import io.github.sasori_256.town_planning.common.event.events.EntitySpawnFailedEvent;
-import io.github.sasori_256.town_planning.common.event.events.EntitySpawnFailureReason;
-import io.github.sasori_256.town_planning.common.event.events.EntitySpawnKind;
-import io.github.sasori_256.town_planning.common.event.events.GameOverEvent;
-import io.github.sasori_256.town_planning.common.event.events.MapUpdatedEvent;
-import io.github.sasori_256.town_planning.common.ui.ImageManager;
 import io.github.sasori_256.town_planning.common.ui.ToastManager;
-import io.github.sasori_256.town_planning.common.ui.gameObjectSelect.controller.CategoryNode;
-import io.github.sasori_256.town_planning.common.ui.gameObjectSelect.controller.NodeMenuInitializer;
-import io.github.sasori_256.town_planning.common.ui.main.scene.EndPanel;
-import io.github.sasori_256.town_planning.common.ui.main.scene.GameMapPanel;
-import io.github.sasori_256.town_planning.common.ui.main.scene.TitlePanel;
-import io.github.sasori_256.town_planning.entity.Camera;
-import io.github.sasori_256.town_planning.entity.model.GameModel;
-import io.github.sasori_256.town_planning.map.controller.GameMapController;
-import io.github.sasori_256.town_planning.map.model.GameMap;
 
 /**
- * ゲームウィンドウを表すクラス。
- * ウィンドウサイズは生成時の設定により決定される。
- * タイトル: "Town Planning Game"
- *
- * @see GameMapPanel
+ * ゲームの画面遷移とトースト表示を担うUIシェル。
  */
 public class GameWindow extends JFrame {
-  private JPanel mainPanel;
-  private CardLayout cardLayout;
-  private GameModel gameModel;
-  private GameMap gameMap;
-  private Camera camera;
-  private EventBus eventBus;
-  private GameMapController gameMapController;
-  private ReadWriteLock stateLock;
-  private ImageManager imageManager;
-  private SceneNavigator sceneNavigator;
-  private EndPanel endPanel;
-  private Timer gameOverTimer;
-  private final AtomicBoolean gameOverHandled = new AtomicBoolean(false);
-  private ToastManager toastManager;
-  private Subscription configSub;
-  private Subscription spawnSub;
-  private Subscription gameOverSub;
-  private Subscription mapSub;
+  private final JPanel mainPanel;
+  private final CardLayout cardLayout;
+  private final Map<SceneId, JComponent> scenes = new EnumMap<>(SceneId.class);
+  private final ToastManager toastManager;
+  private static final int MIN_WIDTH = 640;
+  private static final int MIN_HEIGHT = 480;
 
-  /**
-   * ゲーム描画ウィンドウを初期化する。
-   *
-   * @param gameModel         ゲーム状態を管理するモデル
-   * @param camera            カメラ
-   * @param width             ウィンドウ幅
-   * @param height            ウィンドウ高さ
-   * @param eventBus          イベントバス
-   * @param gameMapController マップ操作コントローラ
-   * @param stateLock         状態ロック
-   * @param imageManager      画像管理マネージャ
-   */
-  public GameWindow(
-      GameModel gameModel,
-      Camera camera,
-      int width,
-      int height,
-      EventBus eventBus,
-      GameMapController gameMapController,
-      ReadWriteLock stateLock,
-      ImageManager imageManager) {
-    this.gameModel = gameModel;
-    this.gameMap = gameModel.getMap();
-    this.camera = camera;
-    this.eventBus = eventBus;
-    this.gameMapController = gameMapController;
-    this.stateLock = stateLock;
-    this.imageManager = imageManager;
-
+  public GameWindow(int width, int height) {
     setTitle("Town Planning Game");
     setSize(width, height);
-    setupCardPanel();
+    setMinimumSize(new Dimension(MIN_WIDTH, MIN_HEIGHT));
     setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
-    this.toastManager = new ToastManager(getLayeredPane(), getLayeredPane());
-    this.configSub = eventBus.subscribe(ConfigLoadFailedEvent.class,
-        event -> this.toastManager.show(buildConfigMessage(event), ToastManager.ToastType.ERROR));
-    this.spawnSub = eventBus.subscribe(EntitySpawnFailedEvent.class,
-        event -> this.toastManager.show(buildSpawnFailureMessage(event), ToastManager.ToastType.WARNING));
-    this.gameOverSub = eventBus.subscribe(GameOverEvent.class, event -> handleGameOver());
-    this.addComponentListener(new ComponentAdapter() {
-      /**
-       * ウィンドウサイズ変更時の処理を行う。
-       *
-       * @param e イベント
-       */
-      @Override
-      public void componentResized(java.awt.event.ComponentEvent e) {
-        repaintCurrentSceneUI();
-        camera.setScreenSize(GameWindow.this.mainPanel.getWidth(), GameWindow.this.mainPanel.getHeight());
-        // MEMO:ウィンドウリサイズ時の処理を追加する場合はここに記載 Cameraの位置修正とか
-      }
-    });
-    this.addWindowListener(new WindowAdapter() {
-      @Override
-      public void windowClosed(WindowEvent e) {
-        cleanupSubscriptions();
-      }
+    this.cardLayout = new CardLayout();
+    this.mainPanel = new JPanel(this.cardLayout);
+    this.add(this.mainPanel, BorderLayout.CENTER);
 
+    this.toastManager = new ToastManager(getLayeredPane(), getLayeredPane());
+    this.addComponentListener(new ComponentAdapter() {
       @Override
-      public void windowClosing(WindowEvent e) {
-        cleanupSubscriptions();
+      public void componentResized(ComponentEvent e) {
+        repaintCurrentSceneUI();
       }
     });
     setVisible(true);
-    GameConfig.reportErrors(eventBus);
   }
 
-  /**
-   * カードレイアウトの初期化を行う。
-   * 各シーンのパネルを作成し、メインパネルに追加する。
-   * シーン切り替えのためのSceneNavigatorも設定する。
-   */
-  private void setupCardPanel() {
-    this.cardLayout = new CardLayout();
-    this.mainPanel = new JPanel(this.cardLayout);
+  public void setScene(SceneId sceneId, JComponent component) {
+    JComponent existing = scenes.put(sceneId, component);
+    if (existing != null) {
+      this.mainPanel.remove(existing);
+    }
+    this.mainPanel.add(component, sceneId.name());
+    this.mainPanel.revalidate();
+    this.mainPanel.repaint();
+  }
 
-    this.sceneNavigator = (sceneName) -> {
-      this.cardLayout.show(this.mainPanel, sceneName);
-      repaintCurrentSceneUI();
-    };
+  public void showScene(SceneId sceneId) {
+    this.cardLayout.show(this.mainPanel, sceneId.name());
+    repaintCurrentSceneUI();
+  }
 
-    JPanel titlePanel = createTitlePanel(this.sceneNavigator);
-    JPanel gameMapPanel = createGameMapPanel();
-    this.endPanel = createEndPanel();
-    // 新しいシーンを追加する場合はここに記載。そのシーン内でシーンを切り替える場合はnavを渡す。
+  public void showToast(String message, ToastManager.ToastType type) {
+    toastManager.show(message, type);
+  }
 
-    this.mainPanel.add(titlePanel, "TITLE");
-    this.mainPanel.add(gameMapPanel, "GAME_MAP");
-    this.mainPanel.add(this.endPanel, "END");
-
-    this.add(this.mainPanel, BorderLayout.CENTER);
+  public Dimension getSceneSize() {
+    return this.mainPanel.getSize();
   }
 
   private void repaintCurrentSceneUI() {
@@ -161,151 +74,5 @@ public class GameWindow extends JFrame {
         ((UiRefreshable) comp).repaintUI();
       }
     }
-  }
-
-  /**
-   * GameMapPanelを作成する。
-   * 
-   * @return GameMapPanelのインスタンス
-   */
-  private JPanel createGameMapPanel() {
-    CategoryNode root = NodeMenuInitializer.setup(this.gameMapController, this.gameModel);
-    GameMapPanel gameMapPanel = new GameMapPanel(this.gameMap, this.gameModel, this.camera, root, this.stateLock,
-        this.imageManager);
-    gameMapPanel.addMouseListener(this.gameMapController);
-    gameMapPanel.addMouseMotionListener(this.gameMapController);
-    gameMapPanel.addMouseWheelListener(this.gameMapController);
-    gameMapPanel.addKeyListener(this.gameMapController);
-    gameMapPanel.setFocusable(true);
-    // TODO: onCloseなる関数でWindowのフレーム破棄時にunsubscribeするようにする
-    this.mapSub = eventBus.subscribe(MapUpdatedEvent.class, event -> {
-      if (SwingUtilities.isEventDispatchThread()) {
-        gameMapPanel.repaint();
-      } else {
-        SwingUtilities.invokeLater(gameMapPanel::repaint);
-      }
-    });
-    return gameMapPanel;
-  }
-
-  /**
-   * TitlePanelを作成する。
-   * 
-   * @param sceneNavigator シーンの切り替えを行うためのSceneNavigator
-   * @return TitlePanelのインスタンス
-   */
-  private JPanel createTitlePanel(SceneNavigator sceneNavigator) {
-    TitlePanel titlePanel = new TitlePanel(sceneNavigator, this.imageManager);
-    return titlePanel;
-  }
-
-  private EndPanel createEndPanel() {
-    return new EndPanel();
-  }
-
-  /**
-   * GameOver時に実行する終了処理。
-   * Eventのunsubscribeやトースト通知、ゲームオーバー画面に表示する要素の引き渡しなどを行う。
-   */
-  private void handleGameOver() {
-    if (!gameOverHandled.compareAndSet(false, true)) {
-      return;
-    }
-    if (toastManager != null) {
-      toastManager.show("住民がいなくなりました。", ToastManager.ToastType.INFO);
-    }
-    if (gameModel.getGameLoop() != null) {
-      gameModel.getGameLoop().pause();
-    }
-    unsubscribe(mapSub);
-    mapSub = null;
-    int day = gameModel.getDay();
-    int soul = gameModel.getSoul();
-    int maxPopulation = gameModel.getPopulationMax();
-    int totalDeaths = gameModel.getPopulationTotalDeaths();
-    SwingUtilities.invokeLater(() -> scheduleGameOverTransition(day, soul, maxPopulation, totalDeaths));
-  }
-
-  private void scheduleGameOverTransition(int day, int soul, int maxPopulation, int totalDeaths) {
-    if (this.endPanel != null) {
-      this.endPanel.setResult(day, soul, maxPopulation, totalDeaths);
-    }
-    if (gameOverTimer != null) {
-      gameOverTimer.stop();
-    }
-    gameOverTimer = new Timer(3000, event -> {
-      if (sceneNavigator != null) {
-        sceneNavigator.changeScene("END");
-      }
-      if (gameModel.getGameLoop() != null) {
-        gameModel.getGameLoop().stop();
-      }
-    });
-    gameOverTimer.setRepeats(false);
-    gameOverTimer.start();
-  }
-
-  private void cleanupSubscriptions() {
-    unsubscribe(mapSub);
-    unsubscribe(configSub);
-    unsubscribe(spawnSub);
-    unsubscribe(gameOverSub);
-    if (gameOverTimer != null) {
-      gameOverTimer.stop();
-      gameOverTimer = null;
-    }
-    mapSub = null;
-    configSub = null;
-    spawnSub = null;
-    gameOverSub = null;
-  }
-
-  private void unsubscribe(Subscription sub) {
-    if (sub != null) {
-      sub.unsubscribe();
-    }
-  }
-
-  private static String buildConfigMessage(ConfigLoadFailedEvent event) {
-    String code = event.code();
-    if ("CONFIG_NOT_FOUND".equals(code)) {
-      return "設定ファイルが見つかりません (game.properties)";
-    }
-    if ("CONFIG_LOAD_FAILED".equals(code)) {
-      return "設定ファイルの読み込みに失敗しました";
-    }
-    if ("CONFIG_PARSE_FAILED".equals(code)) {
-      return "設定値が不正です: " + safeDetail(event.message());
-    }
-    return "設定読み込みエラー: " + safeDetail(event.message());
-  }
-
-  private static String buildSpawnFailureMessage(EntitySpawnFailedEvent event) {
-    String kindName = describeKind(event.kind());
-    EntitySpawnFailureReason reason = event.reason();
-    if (reason == EntitySpawnFailureReason.INSUFFICIENT_SOUL) {
-      return kindName + "を生成できません: 魂が足りません";
-    }
-    if (reason == EntitySpawnFailureReason.INVALID_POSITION) {
-      return kindName + "を生成できません: 設置できない場所です";
-    }
-    if (reason == EntitySpawnFailureReason.PLACEMENT_BLOCKED) {
-      return kindName + "を生成できません: 設置場所が塞がっています";
-    }
-    if (reason == EntitySpawnFailureReason.INVALID_ENTITY) {
-      return kindName + "の生成に失敗しました: 対象が不正です";
-    }
-    return kindName + "の生成に失敗しました";
-  }
-
-  private static String describeKind(EntitySpawnKind kind) {
-    if (kind == EntitySpawnKind.DISASTER) {
-      return "災害";
-    }
-    return "建物";
-  }
-
-  private static String safeDetail(String detail) {
-    return detail == null || detail.isBlank() ? "詳細不明" : detail;
   }
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/SceneId.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/SceneId.java
@@ -1,7 +1,13 @@
 package io.github.sasori_256.town_planning.common.ui.main;
 
+/**
+ * 画面遷移で使用するシーンID。
+ */
 public enum SceneId {
+  /** タイトル画面。 */
   TITLE,
+  /** ゲーム画面。 */
   GAME,
+  /** 結果画面。 */
   END
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/SceneId.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/SceneId.java
@@ -1,0 +1,7 @@
+package io.github.sasori_256.town_planning.common.ui.main;
+
+public enum SceneId {
+  TITLE,
+  GAME,
+  END
+}

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/SceneNavigator.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/SceneNavigator.java
@@ -1,5 +1,13 @@
 package io.github.sasori_256.town_planning.common.ui.main;
 
+/**
+ * レガシー画面遷移のための簡易インターフェース。
+ */
 public interface SceneNavigator {
+  /**
+   * 指定したシーン名へ遷移する。
+   *
+   * @param sceneName シーン識別名
+   */
   void changeScene(String sceneName);
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/UiRefreshable.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/UiRefreshable.java
@@ -1,5 +1,11 @@
 package io.github.sasori_256.town_planning.common.ui.main;
 
+/**
+ * 画面リサイズ時などにUIを再配置するための契約。
+ */
 public interface UiRefreshable {
+  /**
+   * UIの再描画・再配置を実行する。
+   */
   void repaintUI();
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/scene/EndPanel.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/scene/EndPanel.java
@@ -5,16 +5,22 @@ import java.awt.Font;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
+import io.github.sasori_256.town_planning.common.ui.main.GameFlowNavigator;
+import io.github.sasori_256.town_planning.common.ui.main.GameResult;
+
 public class EndPanel extends JPanel {
+  private final GameFlowNavigator navigator;
   private final JLabel dayValue;
   private final JLabel soulValue;
   private final JLabel maxPopulationValue;
   private final JLabel totalDeathsValue;
 
-  public EndPanel() {
+  public EndPanel(GameFlowNavigator navigator) {
+    this.navigator = navigator;
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     setBackground(Color.BLACK);
     setOpaque(true);
@@ -32,6 +38,16 @@ public class EndPanel extends JPanel {
     soulValue = buildStatLine("魂", "-");
     maxPopulationValue = buildStatLine("最大人口", "-");
     totalDeathsValue = buildStatLine("累計死亡数", "-");
+
+    add(Box.createVerticalStrut(16));
+    add(buildActionRow());
+  }
+
+  public void setResult(GameResult result) {
+    if (result == null) {
+      return;
+    }
+    setResult(result.day(), result.soul(), result.maxPopulation(), result.totalDeaths());
   }
 
   public void setResult(int day, int soul, int maxPopulation, int totalDeaths) {
@@ -39,6 +55,24 @@ public class EndPanel extends JPanel {
     soulValue.setText(String.valueOf(soul));
     maxPopulationValue.setText(String.valueOf(maxPopulation));
     totalDeathsValue.setText(String.valueOf(totalDeaths));
+  }
+
+  private JPanel buildActionRow() {
+    JPanel row = new JPanel();
+    row.setOpaque(false);
+    row.setLayout(new BoxLayout(row, BoxLayout.X_AXIS));
+    row.setAlignmentX(CENTER_ALIGNMENT);
+
+    JButton titleButton = new JButton("タイトルへ");
+    titleButton.addActionListener(e -> navigator.goToTitle());
+
+    JButton restartButton = new JButton("もう一度");
+    restartButton.addActionListener(e -> navigator.startNewGame());
+
+    row.add(titleButton);
+    row.add(Box.createHorizontalStrut(12));
+    row.add(restartButton);
+    return row;
   }
 
   private JLabel buildStatLine(String label, String value) {

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/scene/GameMapPanel.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/scene/GameMapPanel.java
@@ -10,12 +10,20 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 
 import javax.swing.JPanel;
+import javax.swing.AbstractAction;
+import javax.swing.JComponent;
+import javax.swing.KeyStroke;
+import java.awt.Graphics;
+import java.awt.geom.Point2D;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 
 import io.github.sasori_256.town_planning.common.ui.AnimationManager;
 import io.github.sasori_256.town_planning.common.ui.ImageManager;
 import io.github.sasori_256.town_planning.common.ui.PaintGameObject;
 import io.github.sasori_256.town_planning.common.ui.gameObjectSelect.controller.CategoryNode;
 import io.github.sasori_256.town_planning.common.ui.gameObjectSelect.view.PaintObjectSelectUI;
+import io.github.sasori_256.town_planning.common.ui.main.GameFlowNavigator;
 import io.github.sasori_256.town_planning.common.ui.main.UiRefreshable;
 import io.github.sasori_256.town_planning.common.ui.resourceViewer.view.PaintResourceViewerUI;
 import io.github.sasori_256.town_planning.entity.Camera;
@@ -40,6 +48,7 @@ public class GameMapPanel extends JPanel implements UiRefreshable {
   private final PaintGameObject paintGameObject;
   private final PaintObjectSelectUI paintObjectSelectUI;
   private final ReadWriteLock stateLock;
+  private final GameFlowNavigator navigator;
 
   /**
    * マップ描画パネルを生成する。
@@ -56,7 +65,8 @@ public class GameMapPanel extends JPanel implements UiRefreshable {
       Camera camera,
       CategoryNode root,
       ReadWriteLock stateLock,
-      ImageManager imageManager) {
+      ImageManager imageManager,
+      GameFlowNavigator navigator) {
     this.gameMap = gameMap;
     this.gameModel = gameModel;
     this.camera = camera;
@@ -65,13 +75,29 @@ public class GameMapPanel extends JPanel implements UiRefreshable {
     this.animationManager = new AnimationManager();
     this.paintGameObject = new PaintGameObject();
     this.stateLock = stateLock;
+    this.navigator = navigator;
     this.setLayout(null);
     setBackground(new Color(19, 175, 251)); // 海の色
     this.paintObjectSelectUI = new PaintObjectSelectUI(imageManager, this, root);
     this.add(new PaintResourceViewerUI(gameModel, imageManager, 1.0));
     paintObjectSelectUI.paint();
+    setupNavigationBindings();
     revalidate();
     repaint();
+  }
+
+  private void setupNavigationBindings() {
+    if (navigator == null) {
+      return;
+    }
+    getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "goTitle");
+    getActionMap().put("goTitle", new AbstractAction() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        navigator.goToTitle();
+      }
+    });
   }
 
   /**
@@ -149,7 +175,7 @@ public class GameMapPanel extends JPanel implements UiRefreshable {
           paintGameObject.paintBuilding(g, entry.pos, gameMap, camera, imageManager,
               animationManager, this);
         } else if (entry.kind == DrawKind.RESIDENT) {
-          paintGameObject.paintResident(g, entry.resident, camera, imageManager, this);
+          paintGameObject.paintResident(g, entry.resident, camera, imageManager, animationManager, this);
         } else if (entry.kind == DrawKind.DISASTER) {
           paintGameObject.paintDisaster(g, entry.disaster, camera, imageManager,
               animationManager, this);

--- a/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/scene/TitlePanel.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/common/ui/main/scene/TitlePanel.java
@@ -9,14 +9,14 @@ import io.github.sasori_256.town_planning.common.ui.CustomButton;
 import io.github.sasori_256.town_planning.common.ui.CustomPanel;
 import io.github.sasori_256.town_planning.common.ui.ImageManager;
 import io.github.sasori_256.town_planning.common.ui.ImageManager.ImageStorage;
-import io.github.sasori_256.town_planning.common.ui.main.SceneNavigator;
+import io.github.sasori_256.town_planning.common.ui.main.GameFlowNavigator;
 
 public class TitlePanel extends JPanel {
-  private SceneNavigator sceneNavigator;
-  private ImageManager imageManager;
+  private final GameFlowNavigator navigator;
+  private final ImageManager imageManager;
 
-  public TitlePanel(SceneNavigator sceneNavigator, ImageManager imageManager) {
-    this.sceneNavigator = sceneNavigator;
+  public TitlePanel(GameFlowNavigator navigator, ImageManager imageManager) {
+    this.navigator = navigator;
     this.imageManager = imageManager;
     initCenterComponent();
   }
@@ -47,7 +47,7 @@ public class TitlePanel extends JPanel {
     } else {
       CustomButton startButton = new CustomButton("Start Game", startImageStorage, 0, 0);
       startButton.addActionListener(e -> {
-        sceneNavigator.changeScene("GAME_MAP");
+        navigator.startNewGame();
       });
       startButton.setAlignmentX(JPanel.CENTER_ALIGNMENT);
       centerPanel.add(startButton);

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/Camera.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/Camera.java
@@ -2,6 +2,7 @@ package io.github.sasori_256.town_planning.entity;
 
 import java.awt.geom.Point2D;
 
+import io.github.sasori_256.town_planning.common.core.GameConfig;
 import io.github.sasori_256.town_planning.common.event.events.MapUpdatedEvent;
 import io.github.sasori_256.town_planning.common.event.EventBus;
 
@@ -20,9 +21,9 @@ public class Camera {
   private int screenWidth;
   private int screenHeight;
   private int zoomLevel;
-  private static final double ZOOM_STEP = 0.25;
-  private static final int MIN_ZOOM_LEVEL = 1; // 0.25倍
-  private static final int MAX_ZOOM_LEVEL = 12; // 3.0倍
+  private static final double ZOOM_STEP = GameConfig.getCameraZoomStep();
+  private static final int MIN_ZOOM_LEVEL = GameConfig.getCameraZoomMinLevel(); // 0.25倍
+  private static final int MAX_ZOOM_LEVEL = GameConfig.getCameraZoomMaxLevel(); // 3.0倍
   private final EventBus eventBus = EventBus.getInstance();
 
   /**

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/building/Building.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/building/Building.java
@@ -77,6 +77,20 @@ public class Building extends BaseGameEntity {
   }
 
   /**
+   * 耐久度にダメージを与える。
+   *
+   * @param damage ダメージ量
+   * @return 破壊された場合はtrue
+   */
+  public boolean applyDamage(int damage) {
+    if (damage <= 0) {
+      return false;
+    }
+    setCurrentDurability(this.currentDurability - damage);
+    return this.currentDurability <= 0;
+  }
+
+  /**
    * 現在の住民数を返す。
    *
    * @return 住民数

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/building/strategy/PopulationGrowthEffect.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/building/strategy/PopulationGrowthEffect.java
@@ -1,5 +1,6 @@
 package io.github.sasori_256.town_planning.entity.building.strategy;
 
+import io.github.sasori_256.town_planning.common.core.GameConfig;
 import io.github.sasori_256.town_planning.entity.building.Building;
 import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
 import io.github.sasori_256.town_planning.entity.model.GameContext;
@@ -17,7 +18,10 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 public class PopulationGrowthEffect implements GameEffect {
   // 住民生成の判定間隔(秒)。
-  private static final double DEFAULT_SPAWN_INTERVAL = 15.0;
+  private static final double SPAWN_INTERVAL = GameConfig.getResidentGrowthSpawnIntervalSeconds();
+  private static final int MIN_HOME_POPULATION = GameConfig.getResidentGrowthMinHomePopulation();
+  private static final double SPAWN_CHANCE =
+      Math.clamp(GameConfig.getResidentGrowthSpawnChance(), 0.0, 1.0);
   private final int maxPopulation;
   private final double spawnInterval;
   private double timer;
@@ -29,7 +33,7 @@ public class PopulationGrowthEffect implements GameEffect {
    */
   public PopulationGrowthEffect(int maxPopulation) {
     this.maxPopulation = maxPopulation;
-    this.spawnInterval = DEFAULT_SPAWN_INTERVAL;
+    this.spawnInterval = SPAWN_INTERVAL;
     this.timer = 0.0;
   }
 
@@ -41,7 +45,7 @@ public class PopulationGrowthEffect implements GameEffect {
     }
     Building building = (Building) self;
     int currentPopulation = building.getCurrentPopulation();
-    if (currentPopulation < 2) {
+    if (currentPopulation < MIN_HOME_POPULATION) {
       return;
     }
     if (currentPopulation >= maxPopulation) {
@@ -54,7 +58,7 @@ public class PopulationGrowthEffect implements GameEffect {
     }
     timer = 0.0;
 
-    if (!ThreadLocalRandom.current().nextBoolean()) {
+    if (ThreadLocalRandom.current().nextDouble() >= SPAWN_CHANCE) {
       return;
     }
 

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/strategy/MeteorDisasterAction.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/strategy/MeteorDisasterAction.java
@@ -2,6 +2,7 @@ package io.github.sasori_256.town_planning.entity.disaster.strategy;
 
 import java.awt.geom.Point2D;
 
+import io.github.sasori_256.town_planning.common.core.GameConfig;
 import io.github.sasori_256.town_planning.common.event.EventBus;
 import io.github.sasori_256.town_planning.common.event.events.DisasterOccurredEvent;
 import io.github.sasori_256.town_planning.entity.disaster.Disaster;
@@ -16,8 +17,9 @@ import io.github.sasori_256.town_planning.entity.model.GameContext;
  */
 public class MeteorDisasterAction implements GameAction {
   private static final String IMPACT_ANIMATION_NAME = "meteor_impact";
-  private static final int IMPACT_ANIMATION_FPS = 6;
-  private static final double IMPACT_EFFECT_DURATION = 1.0;
+  private static final int IMPACT_ANIMATION_FPS = GameConfig.getDisasterMeteorAnimationFps();
+  private static final double IMPACT_EFFECT_DURATION =
+      GameConfig.getDisasterMeteorEffectDurationSeconds();
   private final EventBus eventBus = EventBus.getInstance();
   private final Point2D.Double targetPos;
   private final DisasterType type;
@@ -35,7 +37,7 @@ public class MeteorDisasterAction implements GameAction {
     this.targetPos = new Point2D.Double(targetPos.x, targetPos.y);
     this.type = type;
     this.timer = 0.0;
-    this.impactTime = 2.0;
+    this.impactTime = GameConfig.getDisasterMeteorImpactSeconds();
     this.impacted = false;
   }
 

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/strategy/MeteorDisasterAction.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/disaster/strategy/MeteorDisasterAction.java
@@ -1,19 +1,12 @@
 package io.github.sasori_256.town_planning.entity.disaster.strategy;
 
 import java.awt.geom.Point2D;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import io.github.sasori_256.town_planning.common.event.events.DisasterOccurredEvent;
-import io.github.sasori_256.town_planning.common.event.events.ResidentDiedEvent;
 import io.github.sasori_256.town_planning.entity.disaster.Disaster;
 import io.github.sasori_256.town_planning.entity.disaster.DisasterType;
 import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
 import io.github.sasori_256.town_planning.entity.model.GameAction;
 import io.github.sasori_256.town_planning.entity.model.GameContext;
-import io.github.sasori_256.town_planning.entity.resident.Resident;
-import io.github.sasori_256.town_planning.entity.resident.ResidentState;
 
 /**
  * 隕石などの単発災害のロジック。
@@ -81,32 +74,7 @@ public class MeteorDisasterAction implements GameAction {
     disaster.setPosition(targetPos);
     disaster.setAnimation(IMPACT_ANIMATION_NAME, IMPACT_ANIMATION_FPS, false, true);
 
-    // 範囲内のエンティティを検索
-    // getEntities() がなくなったため、ResidentとBuildingをそれぞれ取得して結合
-    Stream<BaseGameEntity> allEntities = Stream.concat(
-        context.getResidentEntities(),
-        context.getBuildingEntities());
-
-    List<BaseGameEntity> targets = allEntities
-        .filter(e -> e != null && e.getPosition().distance(targetPos) <= type.getRadius())
-        .collect(Collectors.toList());
-
-    for (BaseGameEntity target : targets) {
-      // 住民への処理
-      if (target instanceof Resident) {
-        Resident resident = (Resident) target;
-        if (resident.getState() != ResidentState.DEAD) {
-          // 即死させる
-          resident.markDead();
-          // ResidentDiedEventを発行
-          context.getEventBus().publish(new ResidentDiedEvent(resident, context.getPopulationAlive()));
-        }
-      }
-
-      // 建物への処理 (属性チェックなどで判定)
-      // String buildingType = target.getAttribute("building_type");
-      // if (buildingType != null) { ... }
-    }
+    context.applyDisasterImpact(targetPos, type);
 
     context.getEventBus().publish(new DisasterOccurredEvent(type));
   }

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameContext.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameContext.java
@@ -3,8 +3,10 @@ package io.github.sasori_256.town_planning.entity.model;
 import io.github.sasori_256.town_planning.common.event.EventBus;
 import io.github.sasori_256.town_planning.entity.building.Building;
 import io.github.sasori_256.town_planning.entity.disaster.Disaster;
+import io.github.sasori_256.town_planning.entity.disaster.DisasterType;
 import io.github.sasori_256.town_planning.entity.resident.Resident;
 import io.github.sasori_256.town_planning.map.model.GameMap;
+import java.awt.geom.Point2D;
 
 // Streamとは
 // Streamは、Java 8で導入されたjava.util.streamパッケージに属するクラスであり、
@@ -132,5 +134,13 @@ public interface GameContext {
    * @param <T>    エンティティ型
    */
   <T extends BaseGameEntity> void removeEntity(T entity);
+
+  /**
+   * 天災の影響をゲーム世界に適用する。
+   *
+   * @param center 着弾位置
+   * @param type   天災種別
+   */
+  void applyDisasterImpact(Point2D.Double center, DisasterType type);
 
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
@@ -229,7 +229,7 @@ public class GameModel implements GameContext, SimulationStep {
     }
     double damageRadius = type.getRadius();
     int damage = type.getDamage();
-    double panicRadius = damageRadius + 3.0;
+    double panicRadius = damageRadius + GameConfig.getDisasterPanicRadiusOffsetTiles();
     withWriteLock(() -> {
       killResidentsWithin(center, damageRadius);
       List<Building> destroyed = buildingManager.damageBuildings(this, center, damageRadius, damage);

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
@@ -330,7 +330,12 @@ public class GameModel implements GameContext, SimulationStep {
    * @return 建設できた場合はtrue
    */
   public boolean constructBuilding(Point2D.Double pos, BuildingType type) {
-    return buildingManager.constructBuilding(this, pos, type);
+    boolean constructed = buildingManager.constructBuilding(this, pos, type);
+    if (constructed) {
+      // 建設直後に住民の割り当てを再計算し、空き家への移動を促す。
+      relocationManager.rebalanceResidents();
+    }
+    return constructed;
   }
 
   // getters / setters

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
@@ -43,9 +43,9 @@ import io.github.sasori_256.town_planning.map.model.TerrainType;
  */
 public class GameModel implements GameContext, SimulationStep {
   /** 初期魂所持量。 */
-  private static final int INITIAL_SOUL = 100;
+  private static final int INITIAL_SOUL = GameConfig.getSoulInitialAmount();
   /** アニメーション進行の固定ステップ(秒)。 */
-  private static final double ANIMATION_STEP = 1.0 / 30.0;
+  private static final double ANIMATION_STEP = GameConfig.getAnimationStepSeconds();
 
   /** イベント通知に使用するイベントバス。 */
   private final EventBus eventBus = EventBus.getInstance();

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameModel.java
@@ -1,6 +1,7 @@
 package io.github.sasori_256.town_planning.entity.model;
 
 import java.awt.geom.Point2D;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -13,12 +14,15 @@ import io.github.sasori_256.town_planning.common.core.GameConfig;
 import io.github.sasori_256.town_planning.common.core.GameLoop;
 import io.github.sasori_256.town_planning.common.core.SimulationStep;
 import io.github.sasori_256.town_planning.common.event.EventBus;
+import io.github.sasori_256.town_planning.common.event.events.ResidentDiedEvent;
 import io.github.sasori_256.town_planning.entity.building.Building;
 import io.github.sasori_256.town_planning.entity.building.BuildingType;
 import io.github.sasori_256.town_planning.entity.disaster.Disaster;
+import io.github.sasori_256.town_planning.entity.disaster.DisasterType;
 import io.github.sasori_256.town_planning.entity.model.manager.BuildingManager;
 import io.github.sasori_256.town_planning.entity.model.manager.EntityManager;
 import io.github.sasori_256.town_planning.entity.model.manager.PopulationManager;
+import io.github.sasori_256.town_planning.entity.model.manager.ResidentPanicManager;
 import io.github.sasori_256.town_planning.entity.model.manager.RelocationManager;
 import io.github.sasori_256.town_planning.entity.model.manager.SoulManager;
 import io.github.sasori_256.town_planning.entity.model.manager.TimeManager;
@@ -64,6 +68,8 @@ public class GameModel implements GameContext, SimulationStep {
   private final PopulationManager populationManager;
   /** 建物管理。 */
   private final BuildingManager buildingManager;
+  /** 住民のパニック管理。 */
+  private final ResidentPanicManager residentPanicManager;
 
   /** アニメーション進行用の経過時間バッファ。 */
   private double animationAccumulator = 0.0;
@@ -88,6 +94,7 @@ public class GameModel implements GameContext, SimulationStep {
     this.populationManager = new PopulationManager(eventBus, stateLock, entityManager);
     this.buildingManager = new BuildingManager(eventBus, gameMap, stateLock, soulManager,
         entityManager);
+    this.residentPanicManager = new ResidentPanicManager(stateLock, entityManager);
 
     this.gameLoop = null;
 
@@ -220,6 +227,41 @@ public class GameModel implements GameContext, SimulationStep {
   @Override
   public <T extends BaseGameEntity> void removeEntity(T entity) {
     entityManager.removeEntity(entity, this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void applyDisasterImpact(Point2D.Double center, DisasterType type) {
+    if (center == null || type == null) {
+      return;
+    }
+    double damageRadius = type.getRadius();
+    int damage = type.getDamage();
+    double panicRadius = damageRadius + 3.0;
+    withWriteLock(() -> {
+      killResidentsWithin(center, damageRadius);
+      List<Building> destroyed = buildingManager.damageBuildings(this, center, damageRadius, damage);
+      residentPanicManager.panicResidentsByDestroyedBuildings(this, destroyed);
+      residentPanicManager.panicResidentsInRing(this, center, damageRadius, panicRadius);
+    });
+  }
+
+  private void killResidentsWithin(Point2D.Double center, double radius) {
+    if (center == null || radius <= 0.0) {
+      return;
+    }
+    for (Resident resident : entityManager.snapshotResidents()) {
+      if (resident == null) {
+        continue;
+      }
+      if (resident.getState() == ResidentState.DEAD || resident.getState() == ResidentState.AT_HOME) {
+        continue;
+      }
+      if (resident.getPosition().distance(center) <= radius) {
+        resident.markDead();
+        eventBus.publish(new ResidentDiedEvent(resident, getPopulationAlive()));
+      }
+    }
   }
 
   // --- Game Logic API ---

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameTime.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/GameTime.java
@@ -1,13 +1,15 @@
 package io.github.sasori_256.town_planning.entity.model;
 
+import io.github.sasori_256.town_planning.common.core.GameConfig;
+
 /**
  * ゲーム内時間と日付の進行を管理するクラス。
  */
 public class GameTime {
   private int dayCount = 1;
   private double timeOfDaySeconds = 0.0;
-  private double dayLengthSeconds = 10.0;
-  private double timeScale = 1.0;
+  private double dayLengthSeconds = GameConfig.getTimeDayLengthSeconds();
+  private double timeScale = GameConfig.getTimeScale();
 
   /**
    * 経過時間を進め、進んだ日数を返す。

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/manager/BuildingManager.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/manager/BuildingManager.java
@@ -1,6 +1,8 @@
 package io.github.sasori_256.town_planning.entity.model.manager;
 
 import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Supplier;
@@ -98,6 +100,59 @@ public class BuildingManager {
       eventBus.publish(new MapUpdatedEvent(entity.getPosition()));
       return null;
     });
+  }
+
+  /**
+   * 指定範囲の建物にダメージを与える。
+   *
+   * @param context ゲームコンテキスト
+   * @param center  中心座標
+   * @param radius  影響半径
+   * @param damage  ダメージ量
+   * @return 破壊された建物の一覧
+   */
+  public List<Building> damageBuildings(GameContext context, Point2D.Double center, double radius,
+      int damage) {
+    return withWriteLock(() -> {
+      List<Building> destroyed = new ArrayList<>();
+      if (center == null || radius <= 0.0 || damage <= 0) {
+        return destroyed;
+      }
+      List<Building> candidates = entityManager.snapshotBuildings();
+      for (Building building : candidates) {
+        if (building == null) {
+          continue;
+        }
+        if (!isWithinRadius(building, center, radius)) {
+          continue;
+        }
+        if (building.applyDamage(damage)) {
+          gameMap.removeBuilding(building.getPosition());
+          context.removeEntity(building);
+          destroyed.add(building);
+        }
+      }
+      return destroyed;
+    });
+  }
+
+  private boolean isWithinRadius(Building building, Point2D.Double center, double radius) {
+    BuildingType type = building.getType();
+    boolean[][] footprint = type.getFootprintMask();
+    int originX = building.getOriginX();
+    int originY = building.getOriginY();
+    for (int y = 0; y < type.getHeight(); y++) {
+      for (int x = 0; x < type.getWidth(); x++) {
+        if (!footprint[y][x]) {
+          continue;
+        }
+        Point2D.Double pos = new Point2D.Double(originX + x, originY + y);
+        if (pos.distance(center) <= radius) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/manager/RelocationManager.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/manager/RelocationManager.java
@@ -8,6 +8,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Supplier;
 
+import io.github.sasori_256.town_planning.common.core.GameConfig;
 import io.github.sasori_256.town_planning.entity.building.Building;
 import io.github.sasori_256.town_planning.entity.building.BuildingType;
 import io.github.sasori_256.town_planning.entity.model.CategoryType;
@@ -19,7 +20,8 @@ import io.github.sasori_256.town_planning.entity.resident.ResidentState;
  */
 public class RelocationManager {
   /** 住民再配置で最低限成立させる世帯人数。 */
-  private static final int MIN_RESIDENTS_PER_HOUSE = 2;
+  private static final int MIN_RESIDENTS_PER_HOUSE =
+      GameConfig.getResidentRelocationMinResidentsPerHouse();
   /** 状態同期に使用するロック。 */
   private final ReadWriteLock stateLock;
   /** エンティティ管理。 */

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/manager/RelocationManager.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/manager/RelocationManager.java
@@ -3,14 +3,13 @@ package io.github.sasori_256.town_planning.entity.model.manager;
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Supplier;
 
 import io.github.sasori_256.town_planning.entity.building.Building;
+import io.github.sasori_256.town_planning.entity.building.BuildingType;
 import io.github.sasori_256.town_planning.entity.model.CategoryType;
 import io.github.sasori_256.town_planning.entity.resident.Resident;
 import io.github.sasori_256.town_planning.entity.resident.ResidentState;
@@ -53,8 +52,12 @@ public class RelocationManager {
       }
 
       // 各家の統計情報を設定
-      Map<HomeKey, HouseStats> statsByHome = new HashMap<>();
+      List<HouseInfo> houseInfos = new ArrayList<>();
+      for (Building building : houses) {
+        houseInfos.add(new HouseInfo(building, 0, new ArrayList<>()));
+      }
       int totalResidents = 0;
+      List<Resident> homelessResidents = new ArrayList<>();
       for (Resident resident : entityManager.snapshotResidents()) {
         if (resident.getState() == ResidentState.DEAD) {
           continue;
@@ -65,11 +68,19 @@ public class RelocationManager {
         if (assignedHome == null) {
           continue;
         }
-        HomeKey key = HomeKey.from(assignedHome);
-        HouseStats stats = statsByHome.computeIfAbsent(key, k -> new HouseStats());
-        stats.assignedCount++;
+        HouseInfo info = findHouseInfo(houseInfos, assignedHome);
+        if (info == null) {
+          // 破壊済みの家に紐づいている場合は、再割り当て対象として扱う。
+          if (resident.hasRelocationTarget()) {
+            resident.clearRelocationTarget();
+          }
+          homelessResidents.add(resident);
+          totalResidents++;
+          continue;
+        }
+        info.assignedCount++;
         if (!resident.hasRelocationTarget()) {
-          stats.movableResidents.add(resident);
+          info.movableResidents.add(resident);
         }
         totalResidents++;
       }
@@ -80,17 +91,6 @@ public class RelocationManager {
         return null;
       }
 
-      // 家ごとの統計情報を集計
-      List<HouseInfo> houseInfos = new ArrayList<>();
-      for (Building building : houses) {
-        HomeKey key = HomeKey.from(building.getPosition());
-        HouseStats stats = statsByHome.get(key);
-        int assignedCount = stats != null ? stats.assignedCount : 0;
-        List<Resident> movable = stats != null
-            ? new ArrayList<>(stats.movableResidents)
-            : new ArrayList<>();
-        houseInfos.add(new HouseInfo(building, assignedCount, movable));
-      }
       // 住民数の降順にソートし、人口の多い家を優先的に処理できるようにする。
       houseInfos.sort(Comparator.comparingInt((HouseInfo info) -> info.assignedCount).reversed());
 
@@ -122,7 +122,7 @@ public class RelocationManager {
       }
 
       // 具体的な引っ越し先の決定
-      List<Resident> movers = new ArrayList<>();
+      List<Resident> movers = new ArrayList<>(homelessResidents);
       List<HouseNeed> needs = new ArrayList<>();
       for (int i = 0; i < houseCount; i++) {
         HouseInfo info = houseInfos.get(i);
@@ -163,40 +163,6 @@ public class RelocationManager {
   }
 
   /**
-   * 住民の所属先を世帯単位で集計するためのキー。
-   */
-  private static final class HomeKey {
-    private final int x;
-    private final int y;
-
-    private HomeKey(int x, int y) {
-      this.x = x;
-      this.y = y;
-    }
-
-    private static HomeKey from(Point2D.Double pos) {
-      return new HomeKey((int) Math.round(pos.getX()), (int) Math.round(pos.getY()));
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (this == obj) {
-        return true;
-      }
-      if (!(obj instanceof HomeKey)) {
-        return false;
-      }
-      HomeKey other = (HomeKey) obj;
-      return x == other.x && y == other.y;
-    }
-
-    @Override
-    public int hashCode() {
-      return 31 * x + y;
-    }
-  }
-
-  /**
    * 世帯ごとの割り当て調整に使う作業用情報。
    */
   private static final class HouseInfo {
@@ -225,14 +191,6 @@ public class RelocationManager {
   }
 
   /**
-   * 家ごとの統計情報を保持する作業用モデル。
-   */
-  private static final class HouseStats {
-    private int assignedCount;
-    private final List<Resident> movableResidents = new ArrayList<>();
-  }
-
-  /**
    * 書き込みロック内で処理を実行する。
    *
    * @param supplier 実行処理
@@ -247,5 +205,27 @@ public class RelocationManager {
     } finally {
       writeLock.unlock();
     }
+  }
+
+  private HouseInfo findHouseInfo(List<HouseInfo> houseInfos, Point2D.Double assignedHome) {
+    if (assignedHome == null) {
+      return null;
+    }
+    int homeX = (int) Math.round(assignedHome.getX());
+    int homeY = (int) Math.round(assignedHome.getY());
+    for (HouseInfo info : houseInfos) {
+      Building building = info.building;
+      int localX = homeX - building.getOriginX();
+      int localY = homeY - building.getOriginY();
+      BuildingType type = building.getType();
+      if (localX < 0 || localY < 0 || localX >= type.getWidth() || localY >= type.getHeight()) {
+        continue;
+      }
+      boolean[][] footprint = type.getFootprintMask();
+      if (footprint[localY][localX]) {
+        return info;
+      }
+    }
+    return null;
   }
 }

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/model/manager/ResidentPanicManager.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/model/manager/ResidentPanicManager.java
@@ -1,0 +1,172 @@
+package io.github.sasori_256.town_planning.entity.model.manager;
+
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.function.Supplier;
+
+import io.github.sasori_256.town_planning.entity.building.Building;
+import io.github.sasori_256.town_planning.entity.building.BuildingType;
+import io.github.sasori_256.town_planning.entity.model.GameContext;
+import io.github.sasori_256.town_planning.entity.resident.Resident;
+import io.github.sasori_256.town_planning.entity.resident.ResidentState;
+import io.github.sasori_256.town_planning.map.model.GameMap;
+
+/**
+ * 住民のパニック状態を管理する。
+ */
+public class ResidentPanicManager {
+  private static final int[][] HOME_ENTRY_OFFSETS = {
+      { 0, 1 },
+      { 1, 0 },
+      { 0, -1 },
+      { -1, 0 }
+  };
+
+  /** 状態同期に使用するロック。 */
+  private final ReadWriteLock stateLock;
+  /** エンティティ管理。 */
+  private final EntityManager entityManager;
+
+  /**
+   * 住民パニック管理を生成する。
+   *
+   * @param stateLock     状態ロック
+   * @param entityManager エンティティ管理
+   */
+  public ResidentPanicManager(ReadWriteLock stateLock, EntityManager entityManager) {
+    this.stateLock = stateLock;
+    this.entityManager = entityManager;
+  }
+
+  /**
+   * 指定リング内の住民をパニック状態にする。
+   *
+   * @param context     ゲームコンテキスト
+   * @param center      中心座標
+   * @param innerRadius 内側半径
+   * @param outerRadius 外側半径
+   */
+  public void panicResidentsInRing(GameContext context, Point2D.Double center,
+      double innerRadius, double outerRadius) {
+    if (center == null || outerRadius <= innerRadius) {
+      return;
+    }
+    withWriteLock(() -> {
+      for (Resident resident : entityManager.snapshotResidents()) {
+        if (resident == null) {
+          continue;
+        }
+        double distance = resident.getPosition().distance(center);
+        if (distance > innerRadius && distance <= outerRadius) {
+          applyPanic(context, resident);
+        }
+      }
+      return null;
+    });
+  }
+
+  /**
+   * 破壊された建物の居住者をパニック状態にする。
+   *
+   * @param context   ゲームコンテキスト
+   * @param destroyed 破壊された建物の一覧
+   */
+  public void panicResidentsByDestroyedBuildings(GameContext context, List<Building> destroyed) {
+    if (destroyed == null || destroyed.isEmpty()) {
+      return;
+    }
+    withWriteLock(() -> {
+      for (Resident resident : entityManager.snapshotResidents()) {
+        if (resident == null || resident.getState() == ResidentState.DEAD) {
+          continue;
+        }
+        if (isHomeDestroyed(resident, destroyed)) {
+          applyPanic(context, resident);
+        }
+      }
+      return null;
+    });
+  }
+
+  private boolean isHomeDestroyed(Resident resident, List<Building> destroyed) {
+    Point2D.Double home = resident.getHomePosition();
+    int homeX = (int) Math.round(home.getX());
+    int homeY = (int) Math.round(home.getY());
+    for (Building building : destroyed) {
+      if (building == null) {
+        continue;
+      }
+      BuildingType type = building.getType();
+      int localX = homeX - building.getOriginX();
+      int localY = homeY - building.getOriginY();
+      if (localX < 0 || localY < 0 || localX >= type.getWidth() || localY >= type.getHeight()) {
+        continue;
+      }
+      boolean[][] footprint = type.getFootprintMask();
+      if (footprint[localY][localX]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void applyPanic(GameContext context, Resident resident) {
+    if (resident.getState() == ResidentState.DEAD || resident.getState() == ResidentState.PANICKING) {
+      return;
+    }
+    if (resident.getState() == ResidentState.AT_HOME) {
+      Point2D.Double exit = findHomeExit(context.getMap(), resident.getHomePosition());
+      if (exit != null) {
+        resident.setPosition(exit);
+      }
+    }
+    resident.setState(ResidentState.PANICKING);
+  }
+
+  private Point2D.Double findHomeExit(GameMap map, Point2D.Double home) {
+    if (map == null || home == null) {
+      return null;
+    }
+    int homeX = (int) Math.round(home.getX());
+    int homeY = (int) Math.round(home.getY());
+    List<Point2D.Double> candidates = new ArrayList<>();
+    for (int[] offset : HOME_ENTRY_OFFSETS) {
+      Point2D.Double pos = new Point2D.Double(homeX + offset[0], homeY + offset[1]);
+      if (isWalkable(map, pos)) {
+        candidates.add(pos);
+      }
+    }
+    if (candidates.isEmpty()) {
+      return null;
+    }
+    return candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
+  }
+
+  private boolean isWalkable(GameMap map, Point2D.Double pos) {
+    if (!map.isValidPosition(pos)) {
+      return false;
+    }
+    return map.getCell(pos).canWalk();
+  }
+
+  /**
+   * 書き込みロック内で処理を実行する。
+   *
+   * @param supplier 実行処理
+   * @param <T>      返り値型
+   * @return 実行結果
+   */
+  private <T> T withWriteLock(Supplier<T> supplier) {
+    Lock writeLock = stateLock.writeLock();
+    writeLock.lock();
+    try {
+      return supplier.get();
+    } finally {
+      writeLock.unlock();
+    }
+  }
+}

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/Resident.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/Resident.java
@@ -2,6 +2,7 @@ package io.github.sasori_256.town_planning.entity.resident;
 
 import java.awt.geom.Point2D;
 
+import io.github.sasori_256.town_planning.common.core.GameConfig;
 import io.github.sasori_256.town_planning.common.core.strategy.CompositeUpdateStrategy;
 import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
 import io.github.sasori_256.town_planning.entity.resident.strategy.ResidentBehaviorAction;
@@ -12,7 +13,7 @@ import io.github.sasori_256.town_planning.entity.resident.strategy.ResidentLifeC
  * 住民エンティティを表すクラス。
  */
 public class Resident extends BaseGameEntity {
-  private static final double DEATH_ANIMATION_DURATION = 0.4;
+  private static final double DEATH_ANIMATION_DURATION = GameConfig.getResidentDeathAnimationDurationSeconds();
   private final ResidentType type;
   private Point2D.Double homePosition;
   private Point2D.Double relocationTarget;
@@ -214,8 +215,6 @@ public class Resident extends BaseGameEntity {
     if (state != ResidentState.DEAD) {
       return 0.0;
     }
-    // 一発で終わらせる設定の場合の対応
-    // TODO: Dead codeと検出されているから、設定ファイルから定数を読み込めるようにして対応する
     if (DEATH_ANIMATION_DURATION <= 0.0) {
       return 1.0;
     }

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/Resident.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/Resident.java
@@ -214,6 +214,8 @@ public class Resident extends BaseGameEntity {
     if (state != ResidentState.DEAD) {
       return 0.0;
     }
+    // 一発で終わらせる設定の場合の対応
+    // TODO: Dead codeと検出されているから、設定ファイルから定数を読み込めるようにして対応する
     if (DEATH_ANIMATION_DURATION <= 0.0) {
       return 1.0;
     }

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/DestinationMoveAction.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/DestinationMoveAction.java
@@ -36,10 +36,10 @@ public class DestinationMoveAction implements GameAction {
     FAILED
   }
 
-  private static final double ARRIVAL_EPSILON = 1e-3;
-  private static final double SEARCH_COOLDOWN = 0.5;
-  private static final int MAX_RANDOM_TRIES = 20;
-  private static final long COST_INF = 1_000_000L;
+  private static final double ARRIVAL_EPSILON = GameConfig.getPathfindingArrivalEpsilonTiles();
+  private static final double SEARCH_COOLDOWN = GameConfig.getPathfindingSearchCooldownSeconds();
+  private static final int MAX_RANDOM_TRIES = GameConfig.getPathfindingMaxRandomTries();
+  private static final long COST_INF = GameConfig.getPathfindingCostInf();
 
   private final double speed;
   private final boolean autoDestination;

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/DestinationMoveAction.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/DestinationMoveAction.java
@@ -1,5 +1,6 @@
 package io.github.sasori_256.town_planning.entity.resident.strategy;
 
+import io.github.sasori_256.town_planning.common.core.GameConfig;
 import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
 import io.github.sasori_256.town_planning.entity.model.GameAction;
 import io.github.sasori_256.town_planning.entity.model.GameContext;
@@ -62,7 +63,7 @@ public class DestinationMoveAction implements GameAction {
    */
   public DestinationMoveAction(boolean autoDestination) {
     // タイル単位で速度を管理し、タイルサイズ変更の影響を避ける。
-    this.speed = 2.0; // タイル/秒
+    this.speed = GameConfig.getResidentMoveSpeedTilesPerSecond(); // タイル/秒
     this.autoDestination = autoDestination;
     this.searchCooldown = 0.0;
     this.lastStatus = MoveStatus.IDLE;

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/PanicMoveAction.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/PanicMoveAction.java
@@ -1,0 +1,178 @@
+package io.github.sasori_256.town_planning.entity.resident.strategy;
+
+import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
+import io.github.sasori_256.town_planning.entity.model.GameAction;
+import io.github.sasori_256.town_planning.entity.model.GameContext;
+import io.github.sasori_256.town_planning.map.model.GameMap;
+import java.awt.geom.Point2D;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * パニック時に周囲をあたふた移動するアクション。
+ */
+public class PanicMoveAction implements GameAction {
+  private static final double SPEED = 3.0; // タイル/秒
+  private static final double ARRIVAL_EPSILON = 1e-3;
+  private static final double RETARGET_MIN = 0.2;
+  private static final double RETARGET_MAX = 0.6;
+  private static final double PANIC_DURATION_MIN = 4.0;
+  private static final double PANIC_DURATION_MAX = 8.0;
+  private static final double PANIC_RADIUS = 3.0;
+  private static final int[][] OFFSETS = {
+      { 1, 0 },
+      { -1, 0 },
+      { 0, 1 },
+      { 0, -1 }
+  };
+
+  private boolean active;
+  private double panicDuration;
+  private double panicElapsed;
+  private double retargetCooldown;
+  private Point2D.Double anchor;
+  private Point2D.Double target;
+
+  /**
+   * パニック移動が完了したかを返す。
+   */
+  public boolean isFinished() {
+    return active && panicElapsed >= panicDuration;
+  }
+
+  /**
+   * 内部状態をリセットする。
+   */
+  public void reset() {
+    active = false;
+    panicDuration = 0.0;
+    panicElapsed = 0.0;
+    retargetCooldown = 0.0;
+    anchor = null;
+    target = null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void execute(GameContext context, BaseGameEntity self) {
+    if (context == null || self == null) {
+      return;
+    }
+    GameMap map = context.getMap();
+    if (map == null) {
+      return;
+    }
+    if (!active) {
+      start(self);
+    }
+
+    double dt = context.getDeltaTime();
+    if (dt <= 0.0) {
+      return;
+    }
+
+    panicElapsed += dt;
+    if (panicElapsed >= panicDuration) {
+      return;
+    }
+
+    retargetCooldown = Math.max(0.0, retargetCooldown - dt);
+    if (shouldRetarget(self)) {
+      // 目標を短い間隔で更新し、落ち着きのない移動にする。
+      selectTarget(map, self);
+      retargetCooldown = randomRange(RETARGET_MIN, RETARGET_MAX);
+    }
+
+    moveTowardTarget(self, dt);
+  }
+
+  private void start(BaseGameEntity self) {
+    active = true;
+    Point2D.Double pos = self.getPosition();
+    // パニック開始時の位置を基準に、移動範囲を制限する。
+    anchor = new Point2D.Double(pos.getX(), pos.getY());
+    panicDuration = randomRange(PANIC_DURATION_MIN, PANIC_DURATION_MAX);
+    panicElapsed = 0.0;
+    retargetCooldown = 0.0;
+    target = null;
+  }
+
+  private boolean shouldRetarget(BaseGameEntity self) {
+    if (target == null) {
+      return true;
+    }
+    if (retargetCooldown <= 0.0) {
+      return true;
+    }
+    return self.getPosition().distance(target) <= ARRIVAL_EPSILON;
+  }
+
+  private void selectTarget(GameMap map, BaseGameEntity self) {
+    Point2D.Double current = self.getPosition();
+    int cx = toCellIndex(current.getX(), map.getWidth());
+    int cy = toCellIndex(current.getY(), map.getHeight());
+    int[] order = shuffledOffsets();
+    for (int index : order) {
+      int nx = cx + OFFSETS[index][0];
+      int ny = cy + OFFSETS[index][1];
+      Point2D.Double candidate = new Point2D.Double(nx, ny);
+      if (!map.isValidPosition(candidate)) {
+        continue;
+      }
+      if (!map.getCell(candidate).canWalk()) {
+        continue;
+      }
+      if (anchor != null && candidate.distance(anchor) > PANIC_RADIUS) {
+        continue;
+      }
+      target = candidate;
+      return;
+    }
+    target = new Point2D.Double(current.getX(), current.getY());
+  }
+
+  private void moveTowardTarget(BaseGameEntity self, double dt) {
+    if (target == null) {
+      return;
+    }
+    Point2D.Double pos = self.getPosition();
+    double dx = target.getX() - pos.getX();
+    double dy = target.getY() - pos.getY();
+    double dist = Math.hypot(dx, dy);
+    if (dist <= ARRIVAL_EPSILON) {
+      self.setPosition(new Point2D.Double(target.getX(), target.getY()));
+      return;
+    }
+    double move = Math.min(dist, SPEED * dt);
+    double ratio = move / dist;
+    double nx = pos.getX() + dx * ratio;
+    double ny = pos.getY() + dy * ratio;
+    self.setPosition(new Point2D.Double(nx, ny));
+  }
+
+  private int toCellIndex(double value, int limit) {
+    int index = (int) Math.floor(value);
+    if (index < 0) {
+      return 0;
+    }
+    if (index >= limit) {
+      return limit - 1;
+    }
+    return index;
+  }
+
+  private int[] shuffledOffsets() {
+    int[] order = { 0, 1, 2, 3 };
+    ThreadLocalRandom rng = ThreadLocalRandom.current();
+    for (int i = order.length - 1; i > 0; i--) {
+      int j = rng.nextInt(i + 1);
+      int tmp = order[i];
+      order[i] = order[j];
+      order[j] = tmp;
+    }
+    return order;
+  }
+
+  private double randomRange(double min, double max) {
+    return ThreadLocalRandom.current().nextDouble(min, max);
+  }
+}

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/PanicMoveAction.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/PanicMoveAction.java
@@ -4,6 +4,7 @@ import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
 import io.github.sasori_256.town_planning.entity.model.GameAction;
 import io.github.sasori_256.town_planning.entity.model.GameContext;
 import io.github.sasori_256.town_planning.map.model.GameMap;
+import io.github.sasori_256.town_planning.common.core.GameConfig;
 import java.awt.geom.Point2D;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -11,13 +12,13 @@ import java.util.concurrent.ThreadLocalRandom;
  * パニック時に周囲をあたふた移動するアクション。
  */
 public class PanicMoveAction implements GameAction {
-  private static final double SPEED = 3.0; // タイル/秒
+  private static final double SPEED = GameConfig.getResidentPanicSpeedTilesPerSecond(); // タイル/秒
   private static final double ARRIVAL_EPSILON = 1e-3;
-  private static final double RETARGET_MIN = 0.2;
-  private static final double RETARGET_MAX = 0.6;
-  private static final double PANIC_DURATION_MIN = 4.0;
-  private static final double PANIC_DURATION_MAX = 8.0;
-  private static final double PANIC_RADIUS = 3.0;
+  private static final double RETARGET_MIN = GameConfig.getResidentPanicRetargetMinSeconds();
+  private static final double RETARGET_MAX = GameConfig.getResidentPanicRetargetMaxSeconds();
+  private static final double PANIC_DURATION_MIN = GameConfig.getResidentPanicDurationMinSeconds();
+  private static final double PANIC_DURATION_MAX = GameConfig.getResidentPanicDurationMaxSeconds();
+  private static final double PANIC_RADIUS = GameConfig.getResidentPanicRadiusTiles();
   private static final int[][] OFFSETS = {
       { 1, 0 },
       { -1, 0 },

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/ResidentBehaviorAction.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/ResidentBehaviorAction.java
@@ -64,6 +64,9 @@ public class ResidentBehaviorAction implements GameAction {
     }
 
     ResidentState state = resident.getState();
+    if (state == ResidentState.PANICKING) {
+      return;
+    }
     if (state == ResidentState.AT_HOME) {
       handleAtHome(context, resident, map);
       return;

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/ResidentBehaviorAction.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/ResidentBehaviorAction.java
@@ -38,6 +38,7 @@ public class ResidentBehaviorAction implements GameAction {
   private static final int[][] HOME_ENTRY_OFFSETS = ADJACENT_OFFSETS;
 
   private final DestinationMoveAction mover = new DestinationMoveAction(false);
+  private final PanicMoveAction panicAction = new PanicMoveAction();
   private double workTimer;
   private double homeWaitTimer;
   private double homeWaitDuration;
@@ -65,8 +66,10 @@ public class ResidentBehaviorAction implements GameAction {
 
     ResidentState state = resident.getState();
     if (state == ResidentState.PANICKING) {
+      handlePanicking(context, resident, map);
       return;
     }
+    panicAction.reset();
     if (state == ResidentState.AT_HOME) {
       handleAtHome(context, resident, map);
       return;
@@ -89,7 +92,24 @@ public class ResidentBehaviorAction implements GameAction {
     }
   }
 
+  private void handlePanicking(GameContext context, Resident resident, GameMap map) {
+    panicAction.execute(context, resident);
+    if (panicAction.isFinished()) {
+      panicAction.reset();
+      // パニック中に割り当てられた引っ越し先があれば、移動を再開する。
+      if (resident.hasRelocationTarget()) {
+        resident.setState(ResidentState.RELOCATING);
+        return;
+      }
+      startReturnHome(resident, map);
+    }
+  }
+
   private void handleAtHome(GameContext context, Resident resident, GameMap map) {
+    if (!isHomeAvailable(map, resident.getHomePosition())) {
+      enterIdle(resident, map);
+      return;
+    }
     if (homeWaitDuration <= 0.0) {
       scheduleHomeWait();
     }
@@ -170,6 +190,10 @@ public class ResidentBehaviorAction implements GameAction {
   }
 
   private void handleReturning(GameContext context, Resident resident, GameMap map) {
+    if (!isHomeAvailable(map, resident.getHomePosition())) {
+      enterIdle(resident, map);
+      return;
+    }
     if (!mover.hasDestination()) {
       forceReturnHome(resident, true);
       return;
@@ -189,6 +213,10 @@ public class ResidentBehaviorAction implements GameAction {
   }
 
   private void startReturnHome(Resident resident, GameMap map) {
+    if (!isHomeAvailable(map, resident.getHomePosition())) {
+      enterIdle(resident, map);
+      return;
+    }
     Point2D.Double entry = findHomeEntry(map, resident.getHomePosition());
     if (entry == null) {
       forceReturnHome(resident, true);
@@ -309,6 +337,32 @@ public class ResidentBehaviorAction implements GameAction {
       return null;
     }
     return alternatives.get(ThreadLocalRandom.current().nextInt(alternatives.size()));
+  }
+
+  private boolean isHomeAvailable(GameMap map, Point2D.Double home) {
+    if (map == null || home == null || !map.isValidPosition(home)) {
+      return false;
+    }
+    Building building = map.getCell(home).getBuilding();
+    if (building == null) {
+      return false;
+    }
+    return building.getType().getCategory() == CategoryType.RESIDENTIAL;
+  }
+
+  private void enterIdle(Resident resident, GameMap map) {
+    Point2D.Double home = resident.getHomePosition();
+    if (home != null && resident.getPosition().distance(home) <= HOME_ENTRY_EPSILON) {
+      Point2D.Double exit = findHomeEntry(map, home);
+      if (exit != null) {
+        resident.setPosition(exit);
+      }
+    }
+    resident.setState(ResidentState.IDLE);
+    mover.clearDestination();
+    workTimer = 0.0;
+    homeWaitTimer = 0.0;
+    homeWaitDuration = 0.0;
   }
 
   private Point2D.Double findBuildingEntry(GameMap map, Building building) {

--- a/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/ResidentBehaviorAction.java
+++ b/app/src/main/java/io/github/sasori_256/town_planning/entity/resident/strategy/ResidentBehaviorAction.java
@@ -1,5 +1,6 @@
 package io.github.sasori_256.town_planning.entity.resident.strategy;
 
+import io.github.sasori_256.town_planning.common.core.GameConfig;
 import io.github.sasori_256.town_planning.entity.building.Building;
 import io.github.sasori_256.town_planning.entity.building.BuildingType;
 import io.github.sasori_256.town_planning.entity.model.BaseGameEntity;
@@ -24,9 +25,9 @@ import java.util.stream.Collectors;
  */
 public class ResidentBehaviorAction implements GameAction {
   // Timings are in game seconds unless noted.
-  private static final double WORK_DURATION = 5.0;
-  private static final double HOME_WAIT_MIN = 8.0;
-  private static final double HOME_WAIT_MAX = 20.0;
+  private static final double WORK_DURATION = GameConfig.getResidentWorkDurationSeconds();
+  private static final double HOME_WAIT_MIN = GameConfig.getResidentHomeWaitMinSeconds();
+  private static final double HOME_WAIT_MAX = GameConfig.getResidentHomeWaitMaxSeconds();
   // Distance threshold to treat an entry point as reached.
   private static final double HOME_ENTRY_EPSILON = 0.1;
   private static final int[][] ADJACENT_OFFSETS = {

--- a/app/src/main/resources/game.properties
+++ b/app/src/main/resources/game.properties
@@ -1,14 +1,89 @@
+# 命名規則:
+# - 単位はキー名に含める (Seconds, Tiles, TilesPerSecond など)
+# - 範囲がある値は Min/Max のペアで定義する
+# - 分野ごとにプレフィックスを揃える (corpse.*, resident.*, disaster.*)
+
+# ゲームループの固定タイムステップ(秒)
+game.loop.timeStepSeconds=0.0333333333
+# アニメーション進行の固定ステップ(秒)
+game.animation.stepSeconds=0.0333333333
+
+# 1日の長さ(秒)
+time.dayLengthSeconds=10.0
+# 実時間に対するゲーム内時間の倍率
+time.scale=1.0
+
+# 初期魂所持量
+soul.initialAmount=100
+
+# 遺体から魂を刈り取れるようになるまでの待ち時間(秒)
 corpse.harvestDelaySeconds=2.0
+# 遺体から得られる魂の基準量
 corpse.soulBase=10
+# 信仰値による魂ボーナスの分母 (基準量 / divisor を加算)
 corpse.soulFaithDivisor=5
+
+# 住民が目的地で作業する時間(秒)
 resident.workDurationSeconds=5.0
+# 住民が自宅に留まる待機時間の最小/最大(秒)
 resident.homeWaitMinSeconds=8.0
 resident.homeWaitMaxSeconds=20.0
+# 通常移動の速度(タイル/秒)
 resident.moveSpeedTilesPerSecond=2.0
+
+# 住居による人口増加の最低人口
+resident.growth.minHomePopulation=2
+# 人口増加の判定間隔(秒)
+resident.growth.spawnIntervalSeconds=15.0
+# 人口増加が発生する確率(0.0-1.0)
+resident.growth.spawnChance=0.5
+
+# パニック時の移動速度(タイル/秒)
 resident.panic.speedTilesPerSecond=3.0
+# パニック中に次の移動先を再選択する間隔の最小/最大(秒)
 resident.panic.retargetMinSeconds=0.2
 resident.panic.retargetMaxSeconds=0.6
+# パニック状態が継続する時間の最小/最大(秒)
 resident.panic.durationMinSeconds=4.0
 resident.panic.durationMaxSeconds=8.0
+# パニック移動の基準位置からの最大半径(タイル)
 resident.panic.radiusTiles=3.0
+
+# 住民死亡アニメーションの継続時間(秒)
+resident.death.animationDurationSeconds=0.4
+
+# 住民再配置で最低限成立させる世帯人数
+resident.relocation.minResidentsPerHouse=2
+
+# 経路探索の到達判定誤差(タイル)
+pathfinding.arrivalEpsilonTiles=0.001
+# 目的地探索の再試行クールダウン(秒)
+pathfinding.searchCooldownSeconds=0.5
+# 目的地のランダム試行回数
+pathfinding.maxRandomTries=20
+# 通行不可判定に使う十分大きいコスト値
+pathfinding.costInf=1000000
+
+# カメラのズームステップ(倍率あたり)
+camera.zoom.step=0.25
+# ズームレベルの最小/最大
+camera.zoom.minLevel=1
+camera.zoom.maxLevel=12
+
+# トースト表示時間(ミリ秒)
+ui.toast.displayMillis=3000
+# 同時に表示するトースト数の上限
+ui.toast.maxVisible=3
+# トーストの画面端マージン(ピクセル)
+ui.toast.marginPixels=12
+# トースト同士の間隔(ピクセル)
+ui.toast.spacingPixels=8
+
+# 災害のダメージ半径に対して外側へ広げるパニック半径の加算量(タイル)
 disaster.panicRadiusOffsetTiles=3.0
+# 隕石が着弾するまでの時間(秒)
+disaster.meteor.impactSeconds=2.0
+# 隕石の着弾エフェクトが残る時間(秒)
+disaster.meteor.effectDurationSeconds=1.0
+# 隕石の着弾アニメーションFPS
+disaster.meteor.animationFps=6

--- a/app/src/main/resources/game.properties
+++ b/app/src/main/resources/game.properties
@@ -1,3 +1,14 @@
 corpse.harvestDelaySeconds=2.0
 corpse.soulBase=10
 corpse.soulFaithDivisor=5
+resident.workDurationSeconds=5.0
+resident.homeWaitMinSeconds=8.0
+resident.homeWaitMaxSeconds=20.0
+resident.moveSpeedTilesPerSecond=2.0
+resident.panic.speedTilesPerSecond=3.0
+resident.panic.retargetMinSeconds=0.2
+resident.panic.retargetMaxSeconds=0.6
+resident.panic.durationMinSeconds=4.0
+resident.panic.durationMaxSeconds=8.0
+resident.panic.radiusTiles=3.0
+disaster.panicRadiusOffsetTiles=3.0


### PR DESCRIPTION
## Overview
- GameWindowの責務を切り分けて管理できるようにした
  - 1セッションごとにインスタンス化するものをGameFlowとして切り分け
- ウィンドウのリサイズ時の挙動を修正
- Residentが災害によりパニックを起こすようにした
  - 近くに隕石が落ちる、家にいてるときに家が破壊されるとパニックに
  - パニック中はランダムウォーク
  - パニック後は通常状態に
  - もし帰る家が無かったら引っ越す
- GameConfigとgame.propertiesでゲーム内定数を管理するように変更
  - GameConfigでは定数のバリデーションチェックも行う
  - game.propertiesでは各種定数を定義
  - 隕石のfpsの設定がconflict起こすかも @teruyoshii 